### PR TITLE
新規 - エラー回りの処理を共通化したいため、Fetch処理をラップする

### DIFF
--- a/src/hooks/useFetch/__tests__/useFetch.test.ts
+++ b/src/hooks/useFetch/__tests__/useFetch.test.ts
@@ -2,4 +2,13 @@ import {} from 'vitest';
 import { act, renderHook } from '@testing-library/react';
 import { setupMockServer } from '@/src/mock/test/setup';
 
-describe('useFetch Unit Test', () => {});
+import { handlers } from '@/src/mock/handlers';
+
+const server = setupMockServer(handlers);
+
+describe('useFetch Unit Test', () => {
+    test('通信成功:200', () => {});
+    test('通信エラー:400', () => {});
+    test('通信エラー:404', () => {});
+    test('通信エラー:500', () => {});
+});

--- a/src/hooks/useFetch/__tests__/useFetch.test.ts
+++ b/src/hooks/useFetch/__tests__/useFetch.test.ts
@@ -1,14 +1,64 @@
-import {} from 'vitest';
+import { vi } from 'vitest';
 import { act, renderHook } from '@testing-library/react';
 import { setupMockServer } from '@/src/mock/test/setup';
 
 import { handlers } from '@/src/mock/handlers';
 
+import { useFetch } from '../index';
+import { useFetchAPIHandler, Success } from '../mock/handles';
+
 const server = setupMockServer(handlers);
 
+type Response = {
+    message: string;
+};
+
+const mockPath = 'http://fetch.api.mock/';
+
 describe('useFetch Unit Test', () => {
-    test('通信成功:200', () => {});
-    test('通信エラー:400', () => {});
-    test('通信エラー:404', () => {});
-    test('通信エラー:500', () => {});
+    test('通信成功:200', async () => {
+        const { result } = renderHook(() =>
+            useFetch<Response>({ url: mockPath })
+        );
+
+        const response = await result.current;
+        expect(response.data).toEqual(Success);
+        expect(response.error.status).toEqual(200);
+        expect(response.error.hasError).toEqual(false);
+    });
+    test('通信エラー:400', async () => {
+        server.use(useFetchAPIHandler(400));
+
+        const { result } = renderHook(() =>
+            useFetch<Response>({ url: mockPath })
+        );
+
+        const response = await result.current;
+        expect(response.data).toEqual({});
+        expect(response.error.status).toEqual(400);
+        expect(response.error.hasError).toEqual(true);
+    });
+    test('通信エラー:404', async () => {
+        server.use(useFetchAPIHandler(404));
+
+        const { result } = renderHook(() =>
+            useFetch<Response>({ url: mockPath })
+        );
+
+        const response = await result.current;
+        expect(response.data).toEqual({});
+        expect(response.error.status).toEqual(404);
+        expect(response.error.hasError).toEqual(true);
+    });
+    test('通信エラー:500', async () => {
+        server.use(useFetchAPIHandler(500));
+
+        const { result } = renderHook(() =>
+            useFetch<Response>({ url: mockPath })
+        );
+        const response = await result.current;
+        expect(response.data).toEqual({});
+        expect(response.error.status).toEqual(500);
+        expect(response.error.hasError).toEqual(true);
+    });
 });

--- a/src/hooks/useFetch/__tests__/useFetch.test.ts
+++ b/src/hooks/useFetch/__tests__/useFetch.test.ts
@@ -1,0 +1,5 @@
+import {} from 'vitest';
+import { act, renderHook } from '@testing-library/react';
+import { setupMockServer } from '@/src/mock/test/setup';
+
+describe('useFetch Unit Test', () => {});

--- a/src/hooks/useFetch/index.ts
+++ b/src/hooks/useFetch/index.ts
@@ -1,0 +1,42 @@
+type Error = {
+    hasError: boolean;
+    status: number;
+    message: string;
+};
+
+interface IUseFetch {
+    url: string;
+}
+
+interface IResponse<T> {
+    data: T | {};
+    error: Error;
+}
+
+const defaultError = {
+    hasError: false,
+    status: 200,
+    message: 'Not Message',
+};
+
+export const useFetch = async <T>({
+    url,
+}: IUseFetch): Promise<IResponse<T>> => {
+    const response = await fetch(url).then(async (res) => {
+        if (!res.ok) {
+            return {
+                data: {},
+                error: {
+                    status: res.status,
+                    message: '',
+                    hasError: true,
+                },
+            };
+        }
+        const data = (await res.json()) as T;
+
+        return { data: data, error: defaultError };
+    });
+
+    return response;
+};

--- a/src/hooks/useFetch/index.ts
+++ b/src/hooks/useFetch/index.ts
@@ -33,7 +33,7 @@ export const useFetch = async <T>({
                 },
             };
         }
-        const data = (await res.json()) as T;
+        const data: T = await res.json();
 
         return { data: data, error: defaultError };
     });

--- a/src/hooks/useFetch/mock/handles.ts
+++ b/src/hooks/useFetch/mock/handles.ts
@@ -2,19 +2,20 @@ import { rest } from 'msw';
 
 const path = () => 'http://fetch.api.mock/';
 
-export const useFetchAPIHandler = (status: 200 | 400 | 500 = 200) => {
+export const useFetchAPIHandler = (status: 200 | 400 | 404 | 500 = 200) => {
     return rest.get(path(), async (req, res, ctx) => {
         if (status === 400) {
-            return res(
-                ctx.status(400),
-                ctx.json({ message: 'Bad Request', status: 400 })
-            );
+            return res(ctx.status(400), ctx.json({ message: 'Request Error' }));
+        }
+
+        if (status === 404) {
+            return res(ctx.status(400), ctx.json({ message: 'Not Found' }));
         }
 
         if (status === 500) {
             return res(
                 ctx.status(status),
-                ctx.json({ message: 'Internal Server Error', status: 500 })
+                ctx.json({ message: 'Server Error' })
             );
         }
 

--- a/src/hooks/useFetch/mock/handles.ts
+++ b/src/hooks/useFetch/mock/handles.ts
@@ -1,24 +1,29 @@
 import { rest } from 'msw';
 
-const path = () => 'http://fetch.api.mock/';
+export const Success = { message: 'Success' };
+
+export const RequestError = { message: 'Request Error' };
+
+export const NotFound = { message: 'Not Found' };
+
+export const ServerError = { message: 'Server Error' };
+
+export const path = () => 'http://fetch.api.mock/';
 
 export const useFetchAPIHandler = (status: 200 | 400 | 404 | 500 = 200) => {
     return rest.get(path(), async (req, res, ctx) => {
         if (status === 400) {
-            return res(ctx.status(400), ctx.json({ message: 'Request Error' }));
+            return res(ctx.status(400), ctx.json(RequestError));
         }
 
         if (status === 404) {
-            return res(ctx.status(400), ctx.json({ message: 'Not Found' }));
+            return res(ctx.status(404), ctx.json(NotFound));
         }
 
         if (status === 500) {
-            return res(
-                ctx.status(status),
-                ctx.json({ message: 'Server Error' })
-            );
+            return res(ctx.status(status), ctx.json(ServerError));
         }
 
-        return res(ctx.status(status), ctx.json({ message: 'Success' }));
+        return res(ctx.status(status), ctx.json(Success));
     });
 };

--- a/src/hooks/useFetch/mock/handles.ts
+++ b/src/hooks/useFetch/mock/handles.ts
@@ -1,0 +1,23 @@
+import { rest } from 'msw';
+
+const path = () => 'http://fetch.api.mock/';
+
+export const useFetchAPIHandler = (status: 200 | 400 | 500 = 200) => {
+    return rest.get(path(), async (req, res, ctx) => {
+        if (status === 400) {
+            return res(
+                ctx.status(400),
+                ctx.json({ message: 'Bad Request', status: 400 })
+            );
+        }
+
+        if (status === 500) {
+            return res(
+                ctx.status(status),
+                ctx.json({ message: 'Internal Server Error', status: 500 })
+            );
+        }
+
+        return res(ctx.status(status), ctx.json({ message: 'Success' }));
+    });
+};

--- a/src/mock/handlers.ts
+++ b/src/mock/handlers.ts
@@ -5,9 +5,11 @@ import {
     archiveAPIRouterHandler,
     youtubePostHandler,
 } from '../features/Archives/mock';
+import { useFetchAPIHandler } from '@/src/hooks/useFetch/mock/handles';
 
 export const handlers = [
     channelPostHandler(),
     archiveAPIRouterHandler(),
     youtubePostHandler(),
+    useFetchAPIHandler(),
 ];


### PR DESCRIPTION
## 理由
各ロジック内よりエラー状態をセットするのは、処理がバラけて共通化していないため、各所でテストが必要なためメンテナンス性などが悪い
## 対処
FetchAPIをラップするHookを作り、その中で通信処理などを共通化させる

## 対応出来ていない部分
Hookからの戻り値がPromiseになるため、完全にラップして共通化はできていない