### PR TITLE
反映 - Archives機能周りでエラー画面を作成

### DIFF
--- a/app/_components/ErrorBoundary/ErrorBoundary.tsx
+++ b/app/_components/ErrorBoundary/ErrorBoundary.tsx
@@ -1,0 +1,71 @@
+import { Component, ReactNode } from 'react';
+
+import { CallBackProps } from './type/ErrorMessage';
+import { ErrorBoundaryFallBack } from './ErrorMessage';
+
+interface Props {
+  children: ReactNode;
+  fallback: ({ status }: CallBackProps) => ReactNode;
+}
+
+interface State {
+  hasError: boolean;
+  status: number;
+  message?: string;
+}
+
+const defaultState: State = {
+  hasError: false,
+  status: 200,
+};
+
+const parseErrorCode = (code: string) => {
+  return parseInt(code.substring(0, 3), 10);
+};
+
+/**
+ * ErrorBoundary
+ * @param Props
+ * @param State
+ * @returns ReactNode
+ */
+export class ErrorBoundary extends Component<Props, State> {
+  constructor(props: Props | Readonly<Props>) {
+    super(props);
+    this.state = defaultState;
+  }
+
+  static getDerivedStateFromError(error: Error) {
+    //エラーメッセージを元にエラーステータスを生成させ、エラー画面で表現のエラー文面の切り替えを可能にする
+    const errorCode = parseErrorCode(error.message);
+
+    return {
+      hasError: true,
+      status: errorCode,
+    };
+  }
+
+  render(): React.ReactNode {
+    if (this.state.hasError) {
+      //エラーステータスをフォールバックのコンポーネントへ渡すようにし、コンポーネントの拡張性を持たせる
+      return this.props.fallback({ status: this.state.status });
+    }
+
+    return this.props.children;
+  }
+}
+
+interface ExtendedProps {
+  children: ReactNode;
+}
+
+/**
+ * ErrorBoundaryをステータス毎にエラー画面を表示できるようにした機能拡張版
+ * @param ExtendedProps
+ * @returns
+ */
+export const ErrorBoundaryExtended = ({ children }: ExtendedProps) => {
+  return (
+    <ErrorBoundary fallback={ErrorBoundaryFallBack}>{children}</ErrorBoundary>
+  );
+};

--- a/app/_components/ErrorBoundary/ErrorMessage.tsx
+++ b/app/_components/ErrorBoundary/ErrorMessage.tsx
@@ -1,0 +1,31 @@
+import { useErrorState } from './hook/useErrorState';
+import { CallBackProps } from './type/ErrorMessage';
+
+/**
+ * エラーコードによってメッセージを表示させる
+ * @param status
+ * @returns
+ */
+const ErrorMessage = ({ status }: CallBackProps) => {
+  const message = useErrorState(status);
+  return (
+    <section>
+      <h1>{status}</h1>
+      <span>{message.message}</span>
+      <span>{message.subMessage}</span>
+    </section>
+  );
+};
+
+/**
+ * ErrorMessageを表示させるためのラッパーコンポーネント
+ * @param status
+ * @returns
+ */
+export const ErrorBoundaryFallBack = ({ status }: CallBackProps) => {
+  return (
+    <>
+      <ErrorMessage status={status} />
+    </>
+  );
+};

--- a/app/_components/ErrorBoundary/__tests__/ErrorBoundary.test.tsx
+++ b/app/_components/ErrorBoundary/__tests__/ErrorBoundary.test.tsx
@@ -1,0 +1,70 @@
+import { Suspense } from 'react';
+import '@testing-library/jest-dom';
+import { describe, expect, test, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { ErrorBoundary, ErrorBoundaryExtended } from '../ErrorBoundary';
+import { CallBackProps } from '../type/ErrorMessage';
+
+describe('ErrorBoundary Component Unit TEST', () => {
+  const ChildComponent = () => <div>ChildComponent</div>;
+  const ErrorComponent = () => {
+    throw new Error('404 TEST ERROR');
+  };
+
+  //エラー
+  const FallBackComponent = ({ status }: CallBackProps) => {
+    return <div>{status}</div>;
+  };
+
+  //オリジナルを一旦退避させる
+  //テスト実行時に必ず出力されるConcole.errorがあり、出力画面を汚してしまうのでMockで置き換えて出さないようにする
+  // eslint-disable-next-line no-console
+  const originalConsoleError = console.error;
+
+  beforeEach(() => {
+    //テスト実行時に必ず出力されるConcole.errorがあり、出力画面を汚してしまうのでMockで置き換えて出さないようにする
+    // eslint-disable-next-line no-console
+    console.error = vi.fn();
+  });
+
+  afterEach(() => {
+    //テスト実行時に必ず出力されるConcole.errorがあり、出力画面を汚してしまうのでMockで置き換えて出さないようにする
+    // eslint-disable-next-line no-console
+    console.error = originalConsoleError; // テスト後に元のconsole.errorに戻す
+  });
+
+  test('レンダーエラー', () => {
+    render(
+      <ErrorBoundary fallback={FallBackComponent}>
+        <Suspense>
+          <ChildComponent />
+        </Suspense>
+      </ErrorBoundary>
+    );
+
+    expect(screen.getByText('ChildComponent')).toBeInTheDocument();
+  });
+
+  test('catches and displays error message', () => {
+    render(
+      <ErrorBoundary fallback={FallBackComponent}>
+        <Suspense>
+          <ErrorComponent />
+        </Suspense>
+      </ErrorBoundary>
+    );
+
+    expect(screen.getByText('404')).toBeInTheDocument();
+  });
+});
+
+describe('ErrorBoundaryExtended Component Unit TEST', () => {
+  test('拡張要素が正しく子を表示できるか', () => {
+    render(
+      <ErrorBoundaryExtended>
+        <div>Hello World</div>
+      </ErrorBoundaryExtended>
+    );
+    expect(screen.getByText('Hello World')).toBeInTheDocument();
+  });
+});

--- a/app/_components/ErrorBoundary/__tests__/ErrorMessage.test.tsx
+++ b/app/_components/ErrorBoundary/__tests__/ErrorMessage.test.tsx
@@ -1,0 +1,31 @@
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { RecoilRoot } from 'recoil';
+import { describe, expect, test } from 'vitest';
+import { ErrorBoundaryFallBack } from '../ErrorMessage';
+
+describe('ErrorBoundaryFallBack', () => {
+  test('画面にメッセージが表示できているか', () => {
+    const status = 400;
+    render(
+      <RecoilRoot>
+        <ErrorBoundaryFallBack status={status} />
+      </RecoilRoot>
+    );
+
+    expect(
+      screen.getByText('データ取得時に不具合が発生しました。')
+    ).toBeInTheDocument();
+  });
+
+  test('画面にエラーステータスが表示できているか', () => {
+    const status = 403;
+    render(
+      <RecoilRoot>
+        <ErrorBoundaryFallBack status={status} />
+      </RecoilRoot>
+    );
+
+    expect(screen.getByText('403')).toBeInTheDocument();
+  });
+});

--- a/app/_components/ErrorBoundary/__tests__/useErrorMessage.test.tsx
+++ b/app/_components/ErrorBoundary/__tests__/useErrorMessage.test.tsx
@@ -1,0 +1,73 @@
+import { renderHook } from '@testing-library/react';
+import { describe, test } from 'vitest';
+import { RecoilRoot } from 'recoil';
+import { useErrorState } from '../hook/useErrorState';
+
+describe('useErrorState', () => {
+  test('エラーコード400', () => {
+    const { result } = renderHook(() => useErrorState(400), {
+      wrapper: RecoilRoot,
+    });
+
+    expect(result.current).toEqual({
+      message: 'データ取得時に不具合が発生しました。',
+      subMessage: 'Bad request',
+    });
+  });
+
+  test('エラーコード403', () => {
+    const { result } = renderHook(() => useErrorState(403), {
+      wrapper: RecoilRoot,
+    });
+
+    expect(result.current).toEqual({
+      message: '通信が失敗しました。',
+      subMessage: 'Forbidden',
+    });
+  });
+
+  test('エラーコード404', () => {
+    const { result } = renderHook(() => useErrorState(404), {
+      wrapper: RecoilRoot,
+    });
+
+    expect(result.current).toEqual({
+      message: 'データが存在しません。',
+      subMessage: 'Not Found',
+    });
+  });
+
+  test('エラーコード429', () => {
+    const { result } = renderHook(() => useErrorState(429), {
+      wrapper: RecoilRoot,
+    });
+
+    expect(result.current).toEqual({
+      message:
+        'アクセス過多で通信が行えません。しばらくお時間をおいてください。',
+      subMessage: 'Too Many Requests',
+    });
+  });
+
+  test('エラーコード500', () => {
+    const { result } = renderHook(() => useErrorState(500), {
+      wrapper: RecoilRoot,
+    });
+
+    expect(result.current).toEqual({
+      message: 'サーバー側で不具合が発生しました。',
+      subMessage: 'Internal server error',
+    });
+  });
+
+  test('不明なエラー', () => {
+    const { result } = renderHook(() => useErrorState(999), {
+      wrapper: RecoilRoot,
+    });
+
+    expect(result.current).toEqual({
+      message: '不明なエラーが発生しました',
+      subMessage: 'Unknown error',
+    });
+  });
+});

--- a/app/_components/ErrorBoundary/hook/useErrorState.ts
+++ b/app/_components/ErrorBoundary/hook/useErrorState.ts
@@ -1,0 +1,48 @@
+import { selectorFamily, useRecoilValue } from 'recoil';
+
+import { ErrorMessage } from '@/src/base/Parts/Error/type/ErrorMessage';
+
+const createErrorMessage = (
+  message: string,
+  subMessage: string
+): ErrorMessage => {
+  return { message: message, subMessage: subMessage };
+};
+
+const errorMessage = selectorFamily<ErrorMessage, number>({
+  key: 'data/error-message',
+  get: (code: number) => () => {
+    //それぞれのステータスで文面を変えたいので、ステータスをスイッチで判別させる
+    switch (code) {
+      case 400:
+        return createErrorMessage(
+          'データ取得時に不具合が発生しました。',
+          'Bad request'
+        );
+      case 403:
+        return createErrorMessage('通信が失敗しました。', 'Forbidden');
+      case 404:
+        return createErrorMessage('データが存在しません。', 'Not Found');
+      case 429:
+        return createErrorMessage(
+          'アクセス過多で通信が行えません。しばらくお時間をおいてください。',
+          'Too Many Requests'
+        );
+      case 500:
+        return createErrorMessage(
+          'サーバー側で不具合が発生しました。',
+          'Internal server error'
+        );
+      default:
+        //扱っていないステータスコードが存在した場合は不明なエラーに分類させる
+        return createErrorMessage(
+          '不明なエラーが発生しました',
+          'Unknown error'
+        );
+    }
+  },
+});
+
+export const useErrorState = (code: number) => {
+  return useRecoilValue(errorMessage(code));
+};

--- a/app/_components/ErrorBoundary/index.tsx
+++ b/app/_components/ErrorBoundary/index.tsx
@@ -1,0 +1,1 @@
+export { ErrorBoundaryExtended } from './ErrorBoundary';

--- a/app/_components/ErrorBoundary/type/ErrorMessage.ts
+++ b/app/_components/ErrorBoundary/type/ErrorMessage.ts
@@ -1,0 +1,8 @@
+export interface ErrorMessage {
+  message: string;
+  subMessage: string;
+}
+
+export interface CallBackProps {
+  status: number;
+}

--- a/app/archives/_components/index.tsx
+++ b/app/archives/_components/index.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { Suspense } from 'react';
+import { ErrorBoundaryExtended } from '@/app/_components/ErrorBoundary';
 import { Archives } from './router';
 
 interface IProps {
@@ -10,9 +11,11 @@ interface IProps {
 const ArchivesRoute = ({ channelID }: IProps) => {
   return (
     <div>
-      <Suspense fallback={<div>Route Loading...</div>}>
-        <Archives channelID={channelID} />
-      </Suspense>
+      <ErrorBoundaryExtended>
+        <Suspense fallback={<div>Route Loading...</div>}>
+          <Archives channelID={channelID} />
+        </Suspense>
+      </ErrorBoundaryExtended>
     </div>
   );
 };

--- a/app/archives/layout.tsx
+++ b/app/archives/layout.tsx
@@ -1,12 +1,7 @@
-import { Suspense } from 'react';
-export default function RootLayout({
+export default function ArchiveRootLayout({
   children,
 }: {
   children: React.ReactNode;
 }) {
-  return (
-    <Suspense fallback={<div>Loading...</div>}>
-      <div>{children}</div>
-    </Suspense>
-  );
+  return <div>{children}</div>;
 }


### PR DESCRIPTION
- SuspenseとErrorBoundaryを使い、エラー画面を作成
- 基本構成はYumemiコードチェックで作成したパーツを流用
- 未実装部分は、スタイルと画面表示内容