### PR TITLE
反映 - プロダクト全体のスタイルを調整する

### DIFF
--- a/app/_components/Elements/Icon/index.tsx
+++ b/app/_components/Elements/Icon/index.tsx
@@ -10,8 +10,8 @@ type Props = {
 export const Icon = ({
   src,
   alt,
-  width = 48,
-  height = 48,
+  width = 96,
+  height = 96,
 }: Props): JSX.Element => {
   const youtubeIconURL = process.env.YOUTUBE_CHANNEL_ICON_URL;
   return (

--- a/app/_styles/rootLayout.module.scss
+++ b/app/_styles/rootLayout.module.scss
@@ -11,3 +11,12 @@
     grid-template-rows: repeat(2, 1fr);
   }
 }
+
+.container {
+  margin-left: 10px;
+  margin-right: 10px;
+
+  @include variables.mq(lg) {
+    grid-area: 1 / 2 / 3 / 3;
+  }
+}

--- a/app/_styles/rootPage.module.scss
+++ b/app/_styles/rootPage.module.scss
@@ -1,14 +1,3 @@
-@use '@/_styles/variables/variables.scss';
-
-.rootPage {
-  margin-left: 10px;
-  margin-right: 10px;
-
-  @include variables.mq(lg) {
-    grid-area: 1 / 2 / 3 / 3;
-  }
-}
-
 .content {
   display: flex;
   min-height: 100vh;

--- a/app/api/archives/[channelID]/route.ts
+++ b/app/api/archives/[channelID]/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest } from 'next/server';
-import { fetchExtend } from '@/app/_utile/fetch';
+import { fetchExtend } from '@/_utile/fetch';
 
 export async function GET(
   request: NextRequest,

--- a/app/archives/(hooks)/useArchives.ts
+++ b/app/archives/(hooks)/useArchives.ts
@@ -190,7 +190,7 @@ const archiveListRecursion = selectorFamily<ArchiveListState, Offset>({
               ...rest.contents.archives,
             ],
             mightHaveMore: rest.contents.mightHaveMore,
-            loading: true,
+            loading: false,
           };
         }
       }

--- a/app/archives/(hooks)/useArchives.ts
+++ b/app/archives/(hooks)/useArchives.ts
@@ -6,7 +6,7 @@ import {
   useRecoilCallback,
   useRecoilValue,
 } from 'recoil';
-import { fetchCacheExtend } from '@/app/_utile/fetch';
+import { fetchCacheExtend } from '@/_utile/fetch';
 
 //---------------------------------------------------------------------------
 

--- a/app/archives/[channelID]/error.tsx
+++ b/app/archives/[channelID]/error.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { ErrorBoundaryExtended } from '@/app/_components/ErrorBoundary';
+import { ErrorBoundaryExtended } from '@/_components/ErrorBoundary';
 
 export default function Error({ children }: { children: React.ReactNode }) {
   return <ErrorBoundaryExtended>{children}</ErrorBoundaryExtended>;

--- a/app/archives/[channelID]/layout.tsx
+++ b/app/archives/[channelID]/layout.tsx
@@ -10,7 +10,7 @@ export default function PageChannelLayout({
 }) {
   return (
     <Suspense fallback={<div>Loading...</div>}>
-      <div>{children}</div>
+      <section>{children}</section>
     </Suspense>
   );
 }

--- a/app/archives/[channelID]/loading.tsx
+++ b/app/archives/[channelID]/loading.tsx
@@ -1,4 +1,4 @@
-import { LoadingBasicAnimation } from '@/app/_components/Loading';
+import { LoadingBasicAnimation } from '@/_components/Loading';
 
 export default function Loading() {
   return <LoadingBasicAnimation />;

--- a/app/archives/[channelID]/page.tsx
+++ b/app/archives/[channelID]/page.tsx
@@ -1,7 +1,7 @@
 import dynamic from 'next/dynamic';
 
 const DynamicArchiveClientComponent = dynamic(
-  () => import('@/app/archives/_components'),
+  () => import('@/archives/_components'),
   { ssr: false, loading: () => <div>Loading...</div> }
 );
 

--- a/app/archives/[channelID]/page.tsx
+++ b/app/archives/[channelID]/page.tsx
@@ -11,8 +11,8 @@ export default async function Article({
   params: { channelID: string };
 }) {
   return (
-    <div>
+    <>
       <DynamicArchiveClientComponent channelID={params.channelID} />
-    </div>
+    </>
   );
 }

--- a/app/archives/_components/Archives/index.tsx
+++ b/app/archives/_components/Archives/index.tsx
@@ -20,7 +20,7 @@ export const ArchiveList = ({ Archives }: IProps) => {
     <ul className={styles.container}>
       {Archives.map((archive, index) => (
         <li key={index} className={styles.panel}>
-          <div className="w-1/2 h-1/2 md:w-160 md:h-90 flex-shrink-0">
+          <div className={styles.thumbnail}>
             <a
               href={`https://www.youtube.com/watch?v=${archive.id.videoId}`}
               target="_blank"

--- a/app/archives/_components/Archives/index.tsx
+++ b/app/archives/_components/Archives/index.tsx
@@ -1,5 +1,7 @@
 'use client';
 
+import styles from '@/archives/_styles/archives.module.scss';
+
 interface IProps {
   Archives: GoogleApiYouTubeSearchResource[];
 }
@@ -15,9 +17,9 @@ export const ArchiveList = ({ Archives }: IProps) => {
   };
 
   return (
-    <ul className="list-none w-full">
+    <ul className={styles.container}>
       {Archives.map((archive, index) => (
-        <li key={index} className="flex flex-row box-border p-1 md:p-3">
+        <li key={index} className={styles.panel}>
           <div className="w-1/2 h-1/2 md:w-160 md:h-90 flex-shrink-0">
             <a
               href={`https://www.youtube.com/watch?v=${archive.id.videoId}`}
@@ -31,11 +33,9 @@ export const ArchiveList = ({ Archives }: IProps) => {
             </a>
           </div>
           <div className="flex-grow w-1/4 ml-2 text-gray-50">
-            <div className="flex flex-col  h-1/2 justify-center">
-              <p className="max-h-12 line-clamp-2 text-base md:text-2xl text-left truncate w-full">
-                {archive.snippet.title}
-              </p>
-            </div>
+            <p className="max-h-12 line-clamp-2 text-base md:text-2xl text-left truncate w-full">
+              {archive.snippet.title}
+            </p>
             <div className="text-sm h-1/2 text-gray-400">
               {archive.snippet.publishedAt}
             </div>

--- a/app/archives/_components/Archives/index.tsx
+++ b/app/archives/_components/Archives/index.tsx
@@ -26,16 +26,11 @@ export const ArchiveList = ({ Archives }: IProps) => {
               target="_blank"
               rel="noreferrer"
             >
-              <img
-                src={archive.snippet.thumbnails.medium.url}
-                className="object-cover md:w-160 md:h-90"
-              />
+              <img src={archive.snippet.thumbnails.medium.url} />
             </a>
           </div>
-          <div className="flex-grow w-1/4 ml-2 text-gray-50">
-            <p className="max-h-12 line-clamp-2 text-base md:text-2xl text-left truncate w-full">
-              {archive.snippet.title}
-            </p>
+          <div className={styles.info}>
+            <p className={styles.archive_title}>{archive.snippet.title}</p>
             <div className="text-sm h-1/2 text-gray-400">
               {archive.snippet.publishedAt}
             </div>

--- a/app/archives/_components/Archives/index.tsx
+++ b/app/archives/_components/Archives/index.tsx
@@ -6,12 +6,8 @@ interface IProps {
   Archives: GoogleApiYouTubeSearchResource[];
 }
 
-const createHighQuality720URL = (videoId: string): string => {
-  return `https://i.ytimg.com/vi/${videoId}/hq720.jpg`;
-};
-
 export const ArchiveList = ({ Archives }: IProps) => {
-  const converDayTime = (time: string) => {
+  const convertDayTime = (time: string) => {
     const date = new Date(time);
     return `${date.getFullYear()}年 ${date.getMonth()}月${date.getDate()}日`;
   };
@@ -32,7 +28,7 @@ export const ArchiveList = ({ Archives }: IProps) => {
           <div className={styles.info}>
             <p className={styles.archive_title}>{archive.snippet.title}</p>
             <div className="text-sm h-1/2 text-gray-400">
-              {archive.snippet.publishedAt}
+              {convertDayTime(archive.snippet.publishedAt)}
             </div>
           </div>
         </li>

--- a/app/archives/_components/NextLoad/index.tsx
+++ b/app/archives/_components/NextLoad/index.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { usePage } from '@/app/archives/(hooks)/useArchives';
+import { usePage } from '@/archives/(hooks)/useArchives';
 
 interface IProps {
   channelID: string;

--- a/app/archives/_components/index.tsx
+++ b/app/archives/_components/index.tsx
@@ -10,13 +10,13 @@ interface IProps {
 
 const ArchivesRoute = ({ channelID }: IProps) => {
   return (
-    <div>
+    <>
       <ErrorBoundaryExtended>
         <Suspense fallback={<div>Route Loading...</div>}>
           <Archives channelID={channelID} />
         </Suspense>
       </ErrorBoundaryExtended>
-    </div>
+    </>
   );
 };
 

--- a/app/archives/_components/index.tsx
+++ b/app/archives/_components/index.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { Suspense } from 'react';
-import { ErrorBoundaryExtended } from '@/app/_components/ErrorBoundary';
+import { ErrorBoundaryExtended } from '@/_components/ErrorBoundary';
 import { Archives } from './router';
 
 interface IProps {

--- a/app/archives/_components/router.tsx
+++ b/app/archives/_components/router.tsx
@@ -12,13 +12,13 @@ interface Props {
 export const Archives = ({ channelID }: Props) => {
   const { archives } = useArchives(channelID);
   return (
-    <div>
+    <>
       <ArchiveList Archives={[...archives.archives]} />
       {archives.loading ? (
         <LoadingBasicAnimation />
       ) : (
         <NextLoad channelID={channelID} />
       )}
-    </div>
+    </>
   );
 };

--- a/app/archives/_components/router.tsx
+++ b/app/archives/_components/router.tsx
@@ -1,9 +1,9 @@
 'use client';
 
-import { useArchives } from '@/app/archives/(hooks)/useArchives';
-import { ArchiveList } from '@/app/archives/_components/Archives';
-import { NextLoad } from '@/app/archives/_components/NextLoad';
-import { LoadingBasicAnimation } from '@/app/_components/Loading';
+import { useArchives } from '@/archives/(hooks)/useArchives';
+import { ArchiveList } from '@/archives/_components/Archives';
+import { NextLoad } from '@/archives/_components/NextLoad';
+import { LoadingBasicAnimation } from '@/_components/Loading';
 
 interface Props {
   channelID: string;

--- a/app/archives/_styles/archives.module.scss
+++ b/app/archives/_styles/archives.module.scss
@@ -3,16 +3,27 @@
 .container {
   margin: 0;
   padding: 0;
+  width: 100%;
 }
 
 .panel {
   display: grid;
-  grid-template-columns: 1.5fr 2fr;
-  grid-template-rows: 1fr;
+  grid-template-columns: 1fr;
+  grid-template-rows: 180px 1fr;
   grid-column-gap: 0px;
   grid-row-gap: 0px;
 
   @include variables.mq(lg) {
+    grid-template-columns: 1.5fr 2fr;
+    grid-template-rows: 1fr;
     width: 800px;
+  }
+}
+
+.thumbnail {
+  width: 50%;
+  height: 50%;
+
+  @include variables.mq(lg) {
   }
 }

--- a/app/archives/_styles/archives.module.scss
+++ b/app/archives/_styles/archives.module.scss
@@ -1,0 +1,9 @@
+@use '@/_styles/variables/variables.scss';
+
+.container {
+  display: grid;
+  grid-template-columns: 1.5fr 2fr;
+  grid-template-rows: 1fr;
+  grid-column-gap: 0px;
+  grid-row-gap: 0px;
+}

--- a/app/archives/_styles/archives.module.scss
+++ b/app/archives/_styles/archives.module.scss
@@ -12,6 +12,7 @@
   grid-template-rows: 180px 1fr;
   grid-column-gap: 0px;
   grid-row-gap: 0px;
+  margin-top: 5px;
 
   @include variables.mq(lg) {
     grid-template-columns: 1.5fr 2fr;

--- a/app/archives/_styles/archives.module.scss
+++ b/app/archives/_styles/archives.module.scss
@@ -39,3 +39,18 @@
     grid-area: 1 / 2 / 2 / 3;
   }
 }
+
+.archive_title {
+  margin: 0;
+  padding: 0;
+  width: 100%;
+  overflow: hidden;
+
+  //長すぎるタイトル名の場合のためにline-clampを実装
+  display: -webkit-box;
+  text-overflow: ellipsis;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 2;
+  /* ブラウザがサポートしていない場合のフェールセーフ */
+  max-height: 50px;
+}

--- a/app/archives/_styles/archives.module.scss
+++ b/app/archives/_styles/archives.module.scss
@@ -1,9 +1,18 @@
 @use '@/_styles/variables/variables.scss';
 
 .container {
+  margin: 0;
+  padding: 0;
+}
+
+.panel {
   display: grid;
   grid-template-columns: 1.5fr 2fr;
   grid-template-rows: 1fr;
   grid-column-gap: 0px;
   grid-row-gap: 0px;
+
+  @include variables.mq(lg) {
+    width: 800px;
+  }
 }

--- a/app/archives/_styles/archives.module.scss
+++ b/app/archives/_styles/archives.module.scss
@@ -22,9 +22,20 @@
 }
 
 .thumbnail {
-  width: 50%;
-  height: 50%;
+  grid-area: 1 / 1 / 2 / 2;
+  display: grid;
+  place-content: center;
 
   @include variables.mq(lg) {
+    grid-area: 1 / 1 / 2 / 2;
+  }
+}
+
+.info {
+  grid-area: 2 / 1 / 3 / 2;
+  display: grid;
+  place-content: center;
+  @include variables.mq(lg) {
+    grid-area: 1 / 2 / 2 / 3;
   }
 }

--- a/app/archives/layout.tsx
+++ b/app/archives/layout.tsx
@@ -1,7 +1,0 @@
-export default function ArchiveRootLayout({
-  children,
-}: {
-  children: React.ReactNode;
-}) {
-  return <div>{children}</div>;
-}

--- a/app/channels/[pages]/page.tsx
+++ b/app/channels/[pages]/page.tsx
@@ -1,6 +1,6 @@
 import { cookies, headers } from 'next/headers';
 
-import { Channel } from '@/app/channels/_components/route';
+import { Channel } from '@/channels/_components/route';
 import { Suspense } from 'react';
 // import Error from './error';
 export default async function Article({

--- a/app/channels/_components/ChannelPanel/index.tsx
+++ b/app/channels/_components/ChannelPanel/index.tsx
@@ -14,7 +14,7 @@ export const ChannelPanel = ({ channels }: Props) => {
       {channels.map((channel) => (
         <li key={channel.channelID} className={styles.channel_list}>
           <div className={styles.channel_content}>
-            <div className="row-span-3">
+            <div className={styles.channel_icon}>
               <Link href={`/archives/${channel.channelID}`}>
                 <Icon
                   src={channel.channelIconID}
@@ -22,22 +22,16 @@ export const ChannelPanel = ({ channels }: Props) => {
                 />
               </Link>
             </div>
-            <div className="row-span-1 col-span-2 mt-4 flex flex-col inline-block justify-center items-center \">
+            <div className={styles.channel_info}>
               <Link href={`/archives/${channel.channelID}`}>
-                <div className="flex flex-col">
-                  <span className="text-gray-100 font-sans text-lg">
-                    {channel.name}
-                  </span>
-                  <span className="text-gray-400 font-sans text-sm">
-                    Channel Name
-                  </span>
+                <div className={styles.info_title}>
+                  <span className={styles.info_text}>{channel.name}</span>
+                  <span className={styles.info_channelName}>Channel Name</span>
                 </div>
               </Link>
-              <span className="text-gray-400 font-sans text-xs">
-                Since 2013/8/24
-              </span>
+              <span className={styles.channel_since}>Since 2013/8/24</span>
             </div>
-            <div className="row-span-2 col-span-2">TAGTAGTAGTAGATGA</div>
+            <div className={styles.channel_tag}>TAGTAGTAGTAGATGA</div>
           </div>
         </li>
       ))}

--- a/app/channels/_components/route.tsx
+++ b/app/channels/_components/route.tsx
@@ -1,5 +1,5 @@
-import { getChannel } from '@/app/channels/_lib/api/getChannel';
-import { ChannelPanel } from '@/app/channels/_components/ChannelPanel';
+import { getChannel } from '@/channels/_lib/api/getChannel';
+import { ChannelPanel } from '@/channels/_components/ChannelPanel';
 
 export const Channel = async () => {
   const channels = await getChannel('1');

--- a/app/channels/_style/channelPanel/channelPanel.module.scss
+++ b/app/channels/_style/channelPanel/channelPanel.module.scss
@@ -19,7 +19,8 @@
   max-width: 24rem;
   padding: 4px;
   margin: 2px;
-  background-color: #4a5568;
+  --tw-bg-opacity: 1;
+  background-color: rgba(55, 65, 81, var(--tw-bg-opacity));
   border-radius: 0.25rem;
 
   .channel_content {

--- a/app/channels/_style/channelPanel/channelPanel.module.scss
+++ b/app/channels/_style/channelPanel/channelPanel.module.scss
@@ -21,11 +21,53 @@
   margin: 2px;
   background-color: #4a5568;
   border-radius: 0.25rem;
+
+  .channel_content {
+    display: grid;
+    grid-template-columns: 1fr 3fr;
+    grid-template-rows: 2fr 1fr;
+    grid-column-gap: 0px;
+    grid-row-gap: 0px;
+  }
+
+  .channel_icon {
+    grid-area: 1 / 1 / 3 / 2;
+  }
+
+  .channel_info {
+    grid-area: 1 / 2 / 2 / 3;
+    margin-top: 1rem;
+    display: flex;
+    flex-direction: column;
+    inline-size: auto;
+    justify-content: center;
+    align-items: center;
+  }
+
+  .info_title {
+    display: flex;
+    flex-direction: column;
+  }
+
+  .info_text {
+    color: #f8fafc;
+    font-family: sans-serif;
+    font-size: 1.125rem;
+  }
+
+  .info_channelName {
+    color: #cbd5e0;
+    font-family: sans-serif;
+    font-size: 0.875rem;
+  }
+
+  .channel_since {
+    color: #cbd5e0;
+    font-family: sans-serif;
+    font-size: 0.75rem;
+  }
 }
 
-.channel_content {
-  display: grid;
-  grid-template-rows: repeat(3, minmax(0, 1fr));
-  grid-auto-flow: column;
-  gap: 1rem;
+.channel_tag {
+  grid-area: 2 / 2 / 3 / 3;
 }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -19,7 +19,9 @@ export default function RootLayout({
   return (
     <html lang="jp">
       <body className={styles.rootLayout}>
-        <RecoilProvider>{children}</RecoilProvider>
+        <main className={styles.container}>
+          <RecoilProvider>{children}</RecoilProvider>
+        </main>
       </body>
     </html>
   );

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -14,14 +14,12 @@ const inter = Inter({ subsets: ['latin'] });
 export default async function Home() {
   const channels = await getChannel('1');
   return (
-    <main className={styles.rootPage}>
-      <section className={styles.content}>
-        <ErrorBoundaryExtended>
-          <ChannelPanel channels={channels} />
+    <section className={styles.content}>
+      <ErrorBoundaryExtended>
+        <ChannelPanel channels={channels} />
 
-          <Pagination basePath="channels" currentPageNumber={1} />
-        </ErrorBoundaryExtended>
-      </section>
-    </main>
+        <Pagination basePath="channels" currentPageNumber={1} />
+      </ErrorBoundaryExtended>
+    </section>
   );
 }


### PR DESCRIPTION
- RootLayoutでGridでページ全体の構成を指定することで、各部で指定をせずにするようにする
- チャンネル情報の部分をパネル化して、グリッドで中身の配置をする
- アーカイブページのスタイルをモバイルファーストで指定する
- グリッドで各アーカイブの要素を配置し、モバイルと大画面で要素の配置をレスポンシブで変える