### PR TITLE
反映 - コードレビューで指摘されたポイントを修正

### DIFF
--- a/app/_utile/fetch/index.ts
+++ b/app/_utile/fetch/index.ts
@@ -1,5 +1,3 @@
-import { cache } from 'react';
-
 export type FetchError = {
   hasError: boolean;
   status: number;
@@ -20,12 +18,6 @@ const defaultError = {
   status: 200,
   message: 'Not Message',
 };
-
-export const fetchCacheExtend = cache(
-  async <T>({ url }: IUseFetch): Promise<T> => {
-    return await fetchExtend({ url });
-  }
-);
 
 export const fetchExtend = async <T>({ url }: IUseFetch): Promise<T> => {
   const res = await fetch(url, {

--- a/app/archives/(hooks)/useArchives.ts
+++ b/app/archives/(hooks)/useArchives.ts
@@ -6,7 +6,7 @@ import {
   useRecoilCallback,
   useRecoilValue,
 } from 'recoil';
-import { fetchCacheExtend } from '@/_utile/fetch';
+import { fetchExtend } from '@/_utile/fetch';
 
 //---------------------------------------------------------------------------
 
@@ -91,7 +91,7 @@ const archiveListQuery = selectorFamily<YoutubeDate, QueryInput>({
     ({ channelId, beginTime }) =>
     async () => {
       const query = createQuery({ channelId, beginTime });
-      const archives = await fetchCacheExtend<YoutubeDate>({ url: query });
+      const archives = await fetchExtend<YoutubeDate>({ url: query });
 
       return archives;
     },

--- a/app/archives/(hooks)/useArchives.ts
+++ b/app/archives/(hooks)/useArchives.ts
@@ -232,13 +232,7 @@ export const useArchives = (channelId: string) => {
     set(totalItems(channelId), (count) => count + pageSize);
   });
 
-  const decrementPageSize = useRecoilCallback(
-    ({ set }) =>
-      (channelId: string) => {
-        set(totalItems(channelId), (count) => count - pageSize);
-      }
-  );
-  return { archives, loadNextList, decrementPageSize };
+  return { archives, loadNextList };
 };
 
 /**

--- a/app/archives/[channelID]/layout.tsx
+++ b/app/archives/[channelID]/layout.tsx
@@ -1,16 +1,9 @@
 'use client';
 
-import { Suspense } from 'react';
-import Loading from './loading';
-
 export default function PageChannelLayout({
   children,
 }: {
   children: React.ReactNode;
 }) {
-  return (
-    <Suspense fallback={<div>Loading...</div>}>
-      <section>{children}</section>
-    </Suspense>
-  );
+  return <section>{children}</section>;
 }

--- a/app/archives/[channelID]/page.tsx
+++ b/app/archives/[channelID]/page.tsx
@@ -1,9 +1,8 @@
 import dynamic from 'next/dynamic';
-import { LoadingBasicAnimation } from '@/_components/Loading';
 
 const DynamicArchiveClientComponent = dynamic(
   () => import('@/archives/_components'),
-  { ssr: false, loading: () => <LoadingBasicAnimation /> }
+  { ssr: false }
 );
 
 export default async function Article({

--- a/app/archives/[channelID]/page.tsx
+++ b/app/archives/[channelID]/page.tsx
@@ -11,9 +11,5 @@ export default async function Article({
 }: {
   params: { channelID: string };
 }) {
-  return (
-    <>
-      <DynamicArchiveClientComponent channelID={params.channelID} />
-    </>
-  );
+  return <DynamicArchiveClientComponent channelID={params.channelID} />;
 }

--- a/app/archives/_components/index.tsx
+++ b/app/archives/_components/index.tsx
@@ -11,13 +11,11 @@ interface IProps {
 
 const ArchivesRoute = ({ channelID }: IProps) => {
   return (
-    <>
-      <ErrorBoundaryExtended>
-        <Suspense fallback={<LoadingBasicAnimation />}>
-          <Archives channelID={channelID} />
-        </Suspense>
-      </ErrorBoundaryExtended>
-    </>
+    <ErrorBoundaryExtended>
+      <Suspense fallback={<LoadingBasicAnimation />}>
+        <Archives channelID={channelID} />
+      </Suspense>
+    </ErrorBoundaryExtended>
   );
 };
 

--- a/app/channels/[pages]/loading.tsx
+++ b/app/channels/[pages]/loading.tsx
@@ -1,0 +1,5 @@
+import { LoadingBasicAnimation } from '@/_components/Loading';
+
+export default function Loading() {
+  return <LoadingBasicAnimation />;
+}

--- a/app/channels/[pages]/page.tsx
+++ b/app/channels/[pages]/page.tsx
@@ -10,11 +10,9 @@ export default async function Article({
   params: { pages: string };
 }) {
   return (
-    <div>
-      <Suspense fallback={<LoadingBasicAnimation />}>
-        {/* @ts-expect-error Async Server Component */}
-        <Channel />
-      </Suspense>
-    </div>
+    <Suspense fallback={<LoadingBasicAnimation />}>
+      {/* @ts-expect-error Async Server Component */}
+      <Channel />
+    </Suspense>
   );
 }

--- a/app/channels/[pages]/page.tsx
+++ b/app/channels/[pages]/page.tsx
@@ -1,18 +1,10 @@
-import { cookies, headers } from 'next/headers';
-
 import { Channel } from '@/channels/_components/route';
-import { LoadingBasicAnimation } from '@/_components/Loading';
-import { Suspense } from 'react';
-// import Error from './error';
-export default async function Article({
-  params,
-}: {
-  params: { pages: string };
-}) {
+
+export default async function Article() {
   return (
-    <Suspense fallback={<LoadingBasicAnimation />}>
+    <>
       {/* @ts-expect-error Async Server Component */}
       <Channel />
-    </Suspense>
+    </>
   );
 }

--- a/app/channels/_components/route.tsx
+++ b/app/channels/_components/route.tsx
@@ -3,9 +3,5 @@ import { ChannelPanel } from '@/channels/_components/ChannelPanel';
 
 export const Channel = async () => {
   const channels = await getChannel('1');
-  return (
-    <div>
-      <ChannelPanel channels={channels} />
-    </div>
-  );
+  return <ChannelPanel channels={channels} />;
 };

--- a/app/error.tsx
+++ b/app/error.tsx
@@ -10,8 +10,6 @@ export default function Error({
   reset: () => void;
 }) {
   return (
-    <>
-      <ErrorBoundaryFallBack message={error.message}></ErrorBoundaryFallBack>
-    </>
+    <ErrorBoundaryFallBack message={error.message}></ErrorBoundaryFallBack>
   );
 }

--- a/app/loading.tsx
+++ b/app/loading.tsx
@@ -1,0 +1,5 @@
+import { LoadingBasicAnimation } from '@/_components/Loading';
+
+export default function Loading() {
+  return <LoadingBasicAnimation />;
+}


### PR DESCRIPTION
- Next.jsではFetchAPIを標準で拡張しているので、改めてReactのキャッシュで拡張する必要はない
- 各所でSuspenseでLoadingを使っているが、Next.jsのloading.tsxに分離できるので責務を分離
- ルーティングを1つにまとめるためのDivやセグメントであるが、1つのしかない場合は指定しなくてよい