### PR TITLE
反映 - fetchAPIをMock化する時に、返すデータ構造を変更

### DIFF
--- a/app/_mock/fetch/__tests__/mockHook.test.ts
+++ b/app/_mock/fetch/__tests__/mockHook.test.ts
@@ -10,7 +10,7 @@ describe('FetchをMockするテスト', () => {
     createFetchMock({ success: true, status: 200, data: mockData });
     const { result } = renderHook(() => useTESTHook());
     const data = await result.current;
-    console.log({ data });
+    expect(data).toEqual({ hoge: 'ほげ' });
   });
 
   test('失敗系のテスト', async () => {

--- a/app/_mock/fetch/__tests__/mockHook.ts
+++ b/app/_mock/fetch/__tests__/mockHook.ts
@@ -1,8 +1,6 @@
+import { fetchExtend } from '@/_utile/fetch';
 export const useTESTHook = async () => {
-  const res = await fetch('hogehoge');
-  if (!res.ok) {
-    throw new Error('Error');
-  }
-  const data = await res.json();
-  return data;
+  const result = await fetchExtend({ url: '/hogehoge' });
+
+  return result;
 };

--- a/app/_mock/fetch/index.ts
+++ b/app/_mock/fetch/index.ts
@@ -1,4 +1,4 @@
-import { vi, beforeAll, afterAll } from 'vitest';
+import { vi, afterAll } from 'vitest';
 
 interface IResponse<T> {
   success: boolean;

--- a/app/_mock/fetch/index.ts
+++ b/app/_mock/fetch/index.ts
@@ -18,7 +18,7 @@ export const createFetchMock = <T>({ success, status, data }: IResponse<T>) => {
       resolve({
         ok: success,
         status: status,
-        json: async () => ({ data: { data } }),
+        json: async () => ({ ...data }),
       });
     });
   global.fetch = vi.fn().mockImplementation(dataMock);

--- a/app/archives/__tests__/hooks/useArchives.test.ts
+++ b/app/archives/__tests__/hooks/useArchives.test.ts
@@ -4,11 +4,11 @@ import { act, renderHook, waitFor } from '@testing-library/react';
 import { RecoilRoot, snapshot_UNSTABLE } from 'recoil';
 
 import { useArchives } from '@/archives/(hooks)/useArchives';
-import { createFetchMock } from '@/_mock/fetch';
-import { YoutubeResourceFactory } from '@/archives/__tests__/hooks/mock';
+import { createFetchMock, initMock } from '@/_mock/fetch';
+import { GoogleYoutubeFactory } from '@/archives/__tests__/hooks/mock';
 
 describe('useArchive TEST', () => {
-  const mockYoutubeData = YoutubeResourceFactory();
+  initMock();
   test('初期取得で値を取得できているか', async () => {
     const { result } = renderHook(() => useArchives('Mock'), {
       wrapper: RecoilRoot,

--- a/app/archives/__tests__/hooks/useArchives.test.ts
+++ b/app/archives/__tests__/hooks/useArchives.test.ts
@@ -45,7 +45,4 @@ describe('useArchive TEST', () => {
       expect(archiveResult.result.current.archives.archives.length).toEqual(40);
     });
   });
-  test('エラー発生時は、エラーがthrowされているか', () => {
-    expect(useArchives('Mock')).rejects.toThrowError();
-  });
 });

--- a/app/archives/__tests__/hooks/useArchives.test.ts
+++ b/app/archives/__tests__/hooks/useArchives.test.ts
@@ -9,8 +9,8 @@ import { GoogleYoutubeFactory } from '@/archives/__tests__/hooks/mock';
 
 describe('useArchive TEST', () => {
   initMock();
+  const mockYoutubeData = GoogleYoutubeFactory();
   test('初期取得で値を取得できているか', async () => {
-    const mockYoutubeData = GoogleYoutubeFactory();
     createFetchMock({ success: true, status: 200, data: mockYoutubeData });
     const { result } = renderHook(() => useArchives('Mock'), {
       wrapper: RecoilRoot,

--- a/app/archives/__tests__/hooks/useArchives.test.ts
+++ b/app/archives/__tests__/hooks/useArchives.test.ts
@@ -20,6 +20,7 @@ describe('useArchive TEST', () => {
     });
   });
   test('放送タイトルがFF14に関係ないものだった場合、配列から除外できているか', async () => {
+    createFetchMock({ success: true, status: 200, data: mockYoutubeData });
     const { result } = renderHook(() => useArchives('Mock'), {
       wrapper: RecoilRoot,
     });
@@ -31,6 +32,7 @@ describe('useArchive TEST', () => {
     });
   });
   test('更新をした時件数が増えているか', async () => {
+    createFetchMock({ success: true, status: 200, data: mockYoutubeData });
     const archiveResult = renderHook(() => useArchives('Mock'), {
       wrapper: RecoilRoot,
     });

--- a/app/archives/__tests__/hooks/useArchives.test.ts
+++ b/app/archives/__tests__/hooks/useArchives.test.ts
@@ -10,6 +10,8 @@ import { GoogleYoutubeFactory } from '@/archives/__tests__/hooks/mock';
 describe('useArchive TEST', () => {
   initMock();
   test('初期取得で値を取得できているか', async () => {
+    const mockYoutubeData = GoogleYoutubeFactory();
+    createFetchMock({ success: true, status: 200, data: mockYoutubeData });
     const { result } = renderHook(() => useArchives('Mock'), {
       wrapper: RecoilRoot,
     });

--- a/app/archives/__tests__/hooks/useArchives.test.ts
+++ b/app/archives/__tests__/hooks/useArchives.test.ts
@@ -1,7 +1,7 @@
 import { describe, test, expect } from 'vitest';
 import {} from 'msw';
 import { act, renderHook, waitFor } from '@testing-library/react';
-import { RecoilRoot, snapshot_UNSTABLE } from 'recoil';
+import { RecoilRoot } from 'recoil';
 
 import { useArchives } from '@/archives/(hooks)/useArchives';
 import { createFetchMock, initMock } from '@/_mock/fetch';


### PR DESCRIPTION
- オブジェクトのネスト構造となっていたので、スプレッド構文で引数のdataを展開し使用することで、そのままの構造を維持する
