### PR TITLE
反映 - Fetch拡張関数をPOSTの場合には値を送れるように対応する

### DIFF
--- a/app/(types)/index.ts
+++ b/app/(types)/index.ts
@@ -2,14 +2,11 @@ export interface HikasenVtuber {
   channelID: string;
   name: string;
   channelName: string;
-  channelIconID: string;
+  channelIconURL: string;
   isOfficial: boolean;
-  twitter: string;
-  twitch: string;
-  ffxiv: FFXIV;
-}
-
-interface FFXIV {
+  Twitter: string;
+  Twitch: string;
   dataCenter: string;
   server: string;
+  beginTime: string;
 }

--- a/app/(types)/index.ts
+++ b/app/(types)/index.ts
@@ -3,6 +3,7 @@ export interface HikasenVtuber {
   name: string;
   channelName: string;
   channelIconID: string;
+  isOfficial: boolean;
   twitter: string;
   twitch: string;
   ffxiv: FFXIV;

--- a/app/_utile/fetch/index.ts
+++ b/app/_utile/fetch/index.ts
@@ -4,20 +4,31 @@ export type FetchError = {
   message: string;
 };
 
-interface IUseFetch {
+interface IUseFetch<> {
+  method?: string;
   url: string;
   store?: boolean;
+  body?: object | [];
 }
 
 export const fetchExtend = async <T>({
+  method = 'GET',
   url,
   store = true,
+  body,
 }: IUseFetch): Promise<T> => {
-  const storeFlag: RequestInit = store
-    ? { cache: 'force-cache', method: 'GET' }
-    : { cache: 'no-store', method: 'GET' };
+  const optionInit = (store: boolean, body: object) => {
+    const storeMode: RequestInit = store
+      ? { cache: 'force-cache' }
+      : { cache: 'no-store' };
+    const bodyData: RequestInit =
+      method === 'POST' ? { body: JSON.stringify(body) } : {};
 
-  const res = await fetch(url, storeFlag);
+    return { ...storeMode, ...bodyData };
+  };
+
+  const res = await fetch(url, { method: method, ...optionInit(store, body) });
+
   if (!res.ok) {
     throw new Error(`${res.status}`);
   }

--- a/app/api/control/route.ts
+++ b/app/api/control/route.ts
@@ -11,8 +11,27 @@ export async function GET() {
   const url = `${process.env.CHANNELLIST_URL}`;
 
   const gas = await fetchExtend<HikasenVtuber[]>({ url });
+  const convertChannels: HikasenVtuber[] = gas.map((channel) => {
+    //スプレッドシートからの取得ではJTCではなくUTCになっているため、9時間をたしてJTCにする
+    const time = new Date(channel.beginTime);
+    time.setHours(time.getHours() + 9);
+    const convertTime = time.toISOString();
+
+    return {
+      channelID: channel.channelID,
+      channelIconURL: channel.channelIconURL,
+      channelName: channel.channelName,
+      isOfficial: channel.isOfficial,
+      name: channel.name,
+      Twitter: channel.Twitter,
+      Twitch: channel.Twitch,
+      dataCenter: channel.dataCenter,
+      server: channel.server,
+      beginTime: convertTime,
+    };
+  });
   const db = await prisma.channel.findMany();
-  const response = { gas: gas, db: db };
+  const response = { gas: convertChannels, db: db };
   return new Response(JSON.stringify(response));
 }
 

--- a/app/api/control/route.ts
+++ b/app/api/control/route.ts
@@ -36,13 +36,11 @@ export async function GET() {
 }
 
 export async function POST(request: Request) {
-  const data = await request.json();
-  // const test = await prisma.user.create({
-  //   data: {
-  //     email: `Hiroshi@${name}`,
-  //     name: `Hiroshi${name}`,
-  //   },
-  // });
+  const channel: HikasenVtuber[] = await request.json();
+  await prisma.channel.createMany({
+    data: channel,
+    skipDuplicates: true,
+  });
   return new Response(JSON.stringify('Success'));
 }
 

--- a/app/api/control/route.ts
+++ b/app/api/control/route.ts
@@ -17,14 +17,14 @@ export async function GET() {
 }
 
 export async function POST(request: Request) {
-  const { searchParams } = new URL(request.url);
-  const name = searchParams.get('name');
-  const test = await prisma.user.create({
-    data: {
-      email: `Hiroshi@${name}`,
-      name: `Hiroshi${name}`,
-    },
-  });
+  const data = await request.json();
+  // const test = await prisma.user.create({
+  //   data: {
+  //     email: `Hiroshi@${name}`,
+  //     name: `Hiroshi${name}`,
+  //   },
+  // });
+  return new Response(JSON.stringify('Success'));
 }
 
 export async function DELETE(request: Request) {

--- a/app/channels/_components/ChannelPanel/index.tsx
+++ b/app/channels/_components/ChannelPanel/index.tsx
@@ -18,7 +18,7 @@ export const ChannelPanel = ({ channels }: Props) => {
             <div className={styles.channel_content}>
               <div className={styles.channel_icon}>
                 <Icon
-                  src={`${youtubeIconURL}${channel.channelIconID}`}
+                  src={`${youtubeIconURL}${channel.channelIconURL}`}
                   alt={`${channel.name}のチャンネルアイコン`}
                 />
               </div>

--- a/app/control/(hooks)/useAdminControl.ts
+++ b/app/control/(hooks)/useAdminControl.ts
@@ -77,6 +77,7 @@ export const useAdminControl = () => {
           channelID: channel.channelID,
           channelIconID: channel.channelIconID,
           channelName: channel.channelName,
+          isOfficial: channel.isOfficial,
           name: channel.name,
           twitter: channel.twitter,
           twitch: channel.twitch,

--- a/app/control/(hooks)/useAdminControl.ts
+++ b/app/control/(hooks)/useAdminControl.ts
@@ -3,8 +3,18 @@ import { atom, selector, useRecoilValue, useRecoilCallback } from 'recoil';
 import { fetchExtend } from '@/_utile/fetch';
 import { Channels } from '@/control/(types)';
 import { HikasenVtuber } from '@/(types)';
+import { useCallback } from 'react';
 
 type ControlChannel = HikasenVtuber & { isAllMatched: boolean };
+
+const updateChannel = async (channels: HikasenVtuber[]) => {
+  const res = await fetchExtend({
+    method: 'POST',
+    url: '/api/control/',
+    store: false,
+    body: channels,
+  });
+};
 
 const selectedChannel = atom<Map<string, HikasenVtuber>>({
   key: 'store/selected-channel',
@@ -83,5 +93,9 @@ export const useAdminControl = () => {
       }
   );
 
-  return [channels, selectedChannels, cacheChannel] as const;
+  const updateDataBase = useCallback(() => {
+    updateChannel(selectedChannels);
+  }, [selectedChannels]);
+
+  return [channels, selectedChannels, cacheChannel, updateDataBase] as const;
 };

--- a/app/control/(hooks)/useAdminControl.ts
+++ b/app/control/(hooks)/useAdminControl.ts
@@ -83,13 +83,15 @@ export const useAdminControl = () => {
       (channel: ControlChannel) => {
         const tmpChannel: HikasenVtuber = {
           channelID: channel.channelID,
-          channelIconID: channel.channelIconID,
+          channelIconURL: channel.channelIconURL,
           channelName: channel.channelName,
           isOfficial: channel.isOfficial,
           name: channel.name,
-          twitter: channel.twitter,
-          twitch: channel.twitch,
-          ffxiv: channel.ffxiv,
+          Twitter: channel.Twitter,
+          Twitch: channel.Twitch,
+          dataCenter: channel.dataCenter,
+          server: channel.server,
+          beginTime: channel.beginTime,
         };
         set(selectedChannel, (prev) => {
           //元のに変更を加えたくないので、クローンを作る

--- a/app/control/(hooks)/useAdminControl.ts
+++ b/app/control/(hooks)/useAdminControl.ts
@@ -44,14 +44,23 @@ const channelList = selector<ControlChannel[]>({
   key: 'data-flow/channels-list',
   get: async ({ get }) => {
     const data = get(channelQuery);
-    const channels = data.gas.map((channel, index) => {
-      if (data.db.length === 0) return { ...channel, isAllMatched: false };
+    const channels = data.gas.map((channel) => {
+      //ここで、chennelと同じIDを持つのをdata.dbから取り出し、対象が存在するかを判定する
+      const target = data.db.filter((db_channel) => {
+        return db_channel.channelID === channel.channelID;
+      })[0];
+
+      if (data.db.length === 0 || target === undefined)
+        return { ...channel, isAllMatched: false };
 
       const keys = Object.keys(channel);
-      const target = data.db[index];
+
+      //マッチしているかの判定用変数
       let isMatched = true;
       keys.forEach((key) => {
-        if (channel[key] !== target[key]) {
+        if (channel[key] != target[key]) {
+          //1つでも要素が一致していなかったらFalseにする
+          //でも、これだと要素が変更したときに気づかない可能性がありそう
           isMatched = false;
         }
       });

--- a/app/control/(hooks)/useAdminControl.ts
+++ b/app/control/(hooks)/useAdminControl.ts
@@ -36,7 +36,6 @@ export const channelMapToArray = selector<HikasenVtuber[]>({
   key: 'convert/selected-channel',
   get: ({ get }) => {
     const mapChannels = get(selectedChannel);
-    console.log(mapChannels);
     return [...mapChannels.values()];
   },
 });

--- a/app/control/_components/channelList.tsx
+++ b/app/control/_components/channelList.tsx
@@ -28,7 +28,7 @@ export const ChannelList = () => {
             </div>
             <div className={styles.channel_icon}>
               <Icon
-                src={`${youtubeIconURL}${channel.channelIconID}`}
+                src={`${youtubeIconURL}${channel.channelIconURL}`}
                 alt={`${channel.name}のチャンネルアイコン`}
               />
             </div>

--- a/app/control/_components/channelList.tsx
+++ b/app/control/_components/channelList.tsx
@@ -5,7 +5,8 @@ import styles from '@/control/_styles/channelList.module.scss';
 import { useAdminControl } from '@/control/(hooks)/useAdminControl';
 
 export const ChannelList = () => {
-  const [channels, selectedChannels, selectedChannel] = useAdminControl();
+  const [channels, selectedChannels, selectedChannel, updateDataBase] =
+    useAdminControl();
   const youtubeIconURL = process.env.NEXT_PUBLIC_YOUTUBE_CHANNEL_ICON_URL
     ? process.env.NEXT_PUBLIC_YOUTUBE_CHANNEL_ICON_URL
     : '';
@@ -18,6 +19,7 @@ export const ChannelList = () => {
   return (
     <>
       {selectedChannels.length}件のチャンネルを更新予定
+      <button onClick={() => updateDataBase()}>DBを更新する</button>
       <ul>
         {channels.map((channel, index) => (
           <li className={styles.channels} key={index}>

--- a/prisma/migrations/20230626091111_init/migration.sql
+++ b/prisma/migrations/20230626091111_init/migration.sql
@@ -1,0 +1,8 @@
+/*
+  Warnings:
+
+  - Added the required column `beginTime` to the `Channel` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- AlterTable
+ALTER TABLE "Channel" ADD COLUMN     "beginTime" TEXT NOT NULL;

--- a/prisma/migrations/20230626091214_init/migration.sql
+++ b/prisma/migrations/20230626091214_init/migration.sql
@@ -1,0 +1,9 @@
+/*
+  Warnings:
+
+  - The `beginTime` column on the `Channel` table would be dropped and recreated. This will lead to data loss if there is data in the column.
+
+*/
+-- AlterTable
+ALTER TABLE "Channel" DROP COLUMN "beginTime",
+ADD COLUMN     "beginTime" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP;

--- a/prisma/migrations/20230626094407_init/migration.sql
+++ b/prisma/migrations/20230626094407_init/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "Channel" ALTER COLUMN "beginTime" SET DATA TYPE TIMESTAMPTZ(3);

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -28,14 +28,15 @@ model User {
 }
 
 model Channel {
-  id             Int     @id @default(autoincrement())
-  channelID      String  @unique
+  id             Int      @id @default(autoincrement())
+  channelID      String   @unique
   name           String
   channelName    String
   channelIconURL String
-  isOfficial     Boolean @default(false)
+  isOfficial     Boolean  @default(false)
   dataCenter     String
   server         String
   Twitter        String
   Twitch         String
+  beginTime      DateTime @default(now()) @db.Timestamptz(3)
 }


### PR DESCRIPTION
## Why

Fetch拡張関数はMethodがGET時のみの対応になっていたため、POSTに対応させる

## What

オプションのオブジェクトプロパティを返す関数を作成し、引数によって返すプロパティを動的に変更させるようにする