### PR TITLE
反映 - SupaBaseへ値を追加するロジックを作成

### DIFF
--- a/app/(types)/index.ts
+++ b/app/(types)/index.ts
@@ -2,13 +2,11 @@ export interface HikasenVtuber {
   channelID: string;
   name: string;
   channelName: string;
-  channelIconID: string;
-  twitter: string;
-  twitch: string;
-  ffxiv: FFXIV;
-}
-
-interface FFXIV {
+  channelIconURL: string;
+  isOfficial: boolean;
+  Twitter: string;
+  Twitch: string;
   dataCenter: string;
   server: string;
+  beginTime: string;
 }

--- a/app/_utile/fetch/index.ts
+++ b/app/_utile/fetch/index.ts
@@ -4,20 +4,31 @@ export type FetchError = {
   message: string;
 };
 
-interface IUseFetch {
+interface IUseFetch<> {
+  method?: string;
   url: string;
   store?: boolean;
+  body?: object | [];
 }
 
 export const fetchExtend = async <T>({
+  method = 'GET',
   url,
   store = true,
+  body,
 }: IUseFetch): Promise<T> => {
-  const storeFlag: RequestInit = store
-    ? { cache: 'force-cache', method: 'GET' }
-    : { cache: 'no-store', method: 'GET' };
+  const optionInit = (store: boolean, body: object) => {
+    const storeMode: RequestInit = store
+      ? { cache: 'force-cache' }
+      : { cache: 'no-store' };
+    const bodyData: RequestInit =
+      method === 'POST' ? { body: JSON.stringify(body) } : {};
 
-  const res = await fetch(url, storeFlag);
+    return { ...storeMode, ...bodyData };
+  };
+
+  const res = await fetch(url, { method: method, ...optionInit(store, body) });
+
   if (!res.ok) {
     throw new Error(`${res.status}`);
   }

--- a/app/api/control/route.ts
+++ b/app/api/control/route.ts
@@ -11,20 +11,37 @@ export async function GET() {
   const url = `${process.env.CHANNELLIST_URL}`;
 
   const gas = await fetchExtend<HikasenVtuber[]>({ url });
+  const convertChannels: HikasenVtuber[] = gas.map((channel) => {
+    //スプレッドシートからの取得ではJTCではなくUTCになっているため、9時間をたしてJTCにする
+    const time = new Date(channel.beginTime);
+    time.setHours(time.getHours() + 9);
+    const convertTime = time.toISOString();
+
+    return {
+      channelID: channel.channelID,
+      channelIconURL: channel.channelIconURL,
+      channelName: channel.channelName,
+      isOfficial: channel.isOfficial,
+      name: channel.name,
+      Twitter: channel.Twitter,
+      Twitch: channel.Twitch,
+      dataCenter: channel.dataCenter,
+      server: channel.server,
+      beginTime: convertTime,
+    };
+  });
   const db = await prisma.channel.findMany();
-  const response = { gas: gas, db: db };
+  const response = { gas: convertChannels, db: db };
   return new Response(JSON.stringify(response));
 }
 
 export async function POST(request: Request) {
-  const { searchParams } = new URL(request.url);
-  const name = searchParams.get('name');
-  const test = await prisma.user.create({
-    data: {
-      email: `Hiroshi@${name}`,
-      name: `Hiroshi${name}`,
-    },
+  const channel: HikasenVtuber[] = await request.json();
+  await prisma.channel.createMany({
+    data: channel,
+    skipDuplicates: true,
   });
+  return new Response(JSON.stringify('Success'));
 }
 
 export async function DELETE(request: Request) {

--- a/app/channels/_components/ChannelPanel/index.tsx
+++ b/app/channels/_components/ChannelPanel/index.tsx
@@ -18,7 +18,7 @@ export const ChannelPanel = ({ channels }: Props) => {
             <div className={styles.channel_content}>
               <div className={styles.channel_icon}>
                 <Icon
-                  src={`${youtubeIconURL}${channel.channelIconID}`}
+                  src={`${youtubeIconURL}${channel.channelIconURL}`}
                   alt={`${channel.name}のチャンネルアイコン`}
                 />
               </div>

--- a/app/control/_components/channelList.tsx
+++ b/app/control/_components/channelList.tsx
@@ -5,7 +5,8 @@ import styles from '@/control/_styles/channelList.module.scss';
 import { useAdminControl } from '@/control/(hooks)/useAdminControl';
 
 export const ChannelList = () => {
-  const [channels, selectedChannels, selectedChannel] = useAdminControl();
+  const [channels, selectedChannels, selectedChannel, updateDataBase] =
+    useAdminControl();
   const youtubeIconURL = process.env.NEXT_PUBLIC_YOUTUBE_CHANNEL_ICON_URL
     ? process.env.NEXT_PUBLIC_YOUTUBE_CHANNEL_ICON_URL
     : '';
@@ -18,6 +19,7 @@ export const ChannelList = () => {
   return (
     <>
       {selectedChannels.length}件のチャンネルを更新予定
+      <button onClick={() => updateDataBase()}>DBを更新する</button>
       <ul>
         {channels.map((channel, index) => (
           <li className={styles.channels} key={index}>
@@ -26,7 +28,7 @@ export const ChannelList = () => {
             </div>
             <div className={styles.channel_icon}>
               <Icon
-                src={`${youtubeIconURL}${channel.channelIconID}`}
+                src={`${youtubeIconURL}${channel.channelIconURL}`}
                 alt={`${channel.name}のチャンネルアイコン`}
               />
             </div>

--- a/prisma/migrations/20230626091111_init/migration.sql
+++ b/prisma/migrations/20230626091111_init/migration.sql
@@ -1,0 +1,8 @@
+/*
+  Warnings:
+
+  - Added the required column `beginTime` to the `Channel` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- AlterTable
+ALTER TABLE "Channel" ADD COLUMN     "beginTime" TEXT NOT NULL;

--- a/prisma/migrations/20230626091214_init/migration.sql
+++ b/prisma/migrations/20230626091214_init/migration.sql
@@ -1,0 +1,9 @@
+/*
+  Warnings:
+
+  - The `beginTime` column on the `Channel` table would be dropped and recreated. This will lead to data loss if there is data in the column.
+
+*/
+-- AlterTable
+ALTER TABLE "Channel" DROP COLUMN "beginTime",
+ADD COLUMN     "beginTime" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP;

--- a/prisma/migrations/20230626094407_init/migration.sql
+++ b/prisma/migrations/20230626094407_init/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "Channel" ALTER COLUMN "beginTime" SET DATA TYPE TIMESTAMPTZ(3);

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -28,14 +28,15 @@ model User {
 }
 
 model Channel {
-  id             Int     @id @default(autoincrement())
-  channelID      String  @unique
+  id             Int      @id @default(autoincrement())
+  channelID      String   @unique
   name           String
   channelName    String
   channelIconURL String
-  isOfficial     Boolean @default(false)
+  isOfficial     Boolean  @default(false)
   dataCenter     String
   server         String
   Twitter        String
   Twitch         String
+  beginTime      DateTime @default(now()) @db.Timestamptz(3)
 }


### PR DESCRIPTION
## Why

SupaBaseへSpreadSheetから取得した値を追加する

## What

Spreadsheetの構成をSupaBaseのテーブル構成に合わせて変更する
Spreadsheetから取得した日付はUTC基準なので、9時間足してJTCにする
Fetch拡張関数を変更し、POSTのMethodにも対応できるようにする