### PR TITLE
反映 - PrismaでDBの値を取得する部分を統一

### DIFF
--- a/app/(types)/index.ts
+++ b/app/(types)/index.ts
@@ -8,5 +8,5 @@ export interface HikasenVtuber {
   Twitch: string;
   dataCenter: string;
   server: string;
-  beginTime: string;
+  beginTime: string | Date;
 }

--- a/app/_utile/convert/DayTime.ts
+++ b/app/_utile/convert/DayTime.ts
@@ -1,0 +1,4 @@
+export default function (time: string | Date) {
+  const date = new Date(time);
+  return `${date.getFullYear()}年 ${date.getMonth() + 1}月${date.getDate()}日`;
+}

--- a/app/_utile/prisma/index.ts
+++ b/app/_utile/prisma/index.ts
@@ -1,0 +1,7 @@
+import { PrismaClient } from '@prisma/client';
+
+const prisma = new PrismaClient({
+  log: ['query', 'error', 'info', 'warn'],
+});
+
+export default prisma;

--- a/app/_utile/prisma/index.ts
+++ b/app/_utile/prisma/index.ts
@@ -1,7 +1,21 @@
+import { HikasenVtuber } from '@/(types)';
 import { PrismaClient } from '@prisma/client';
 
 const prisma = new PrismaClient({
   log: ['query', 'error', 'info', 'warn'],
 });
+
+export const getChannelOffset = async (): Promise<HikasenVtuber[]> => {
+  const res = await prisma.channel.findMany({
+    orderBy: [
+      {
+        isOfficial: 'desc',
+      },
+      { beginTime: 'desc' },
+    ],
+  });
+
+  return res;
+};
 
 export default prisma;

--- a/app/api/control/route.ts
+++ b/app/api/control/route.ts
@@ -1,11 +1,7 @@
 import { fetchExtend } from '@/_utile/fetch';
 import { HikasenVtuber } from '@/(types)/';
 
-import { PrismaClient } from '@prisma/client';
-
-const prisma = new PrismaClient({
-  log: ['query', 'error', 'info', 'warn'],
-});
+import prisma from '@/_utile/prisma';
 
 export async function GET() {
   const url = `${process.env.CHANNELLIST_URL}`;

--- a/app/archives/_components/Archives/index.tsx
+++ b/app/archives/_components/Archives/index.tsx
@@ -1,19 +1,13 @@
 'use client';
 
 import styles from '@/archives/_styles/archives.module.scss';
+import DayTime from '@/_utile/convert/DayTime';
 
 interface IProps {
   Archives: GoogleApiYouTubeSearchResource[];
 }
 
 export const ArchiveList = ({ Archives }: IProps) => {
-  const convertDayTime = (time: string) => {
-    const date = new Date(time);
-    return `${date.getFullYear()}年 ${
-      date.getMonth() + 1
-    }月${date.getDate()}日`;
-  };
-
   return (
     <ul className={styles.container}>
       {Archives.map((archive, index) => (
@@ -30,7 +24,7 @@ export const ArchiveList = ({ Archives }: IProps) => {
           <div className={styles.info}>
             <p className={styles.archive_title}>{archive.snippet.title}</p>
             <div className={styles.live_daytime}>
-              {convertDayTime(archive.snippet.publishedAt)}
+              {DayTime(archive.snippet.publishedAt)}
             </div>
           </div>
         </li>

--- a/app/channels/_components/ChannelPanel/index.tsx
+++ b/app/channels/_components/ChannelPanel/index.tsx
@@ -3,6 +3,7 @@ import Link from 'next/link';
 import styles from '@/channels/_style/channelPanel/channelPanel.module.scss';
 import { Icon } from '@/_components/Elements/Icon';
 import { HikasenVtuber } from '@/(types)';
+import DayTime from '@/_utile/convert/DayTime';
 
 type Props = {
   channels: HikasenVtuber[];
@@ -30,7 +31,9 @@ export const ChannelPanel = ({ channels }: Props) => {
                   </span>
                 </div>
 
-                <span className={styles.channel_since}>Since 2013/8/24</span>
+                <span className={styles.channel_since}>
+                  {DayTime(channel.beginTime)}
+                </span>
               </div>
               <div className={styles.channel_tag}></div>
             </div>

--- a/app/channels/_lib/api/getChannel.ts
+++ b/app/channels/_lib/api/getChannel.ts
@@ -1,5 +1,5 @@
 import { HikasenVtuber } from '@/(types)/';
-import prisma from '@/_utile/prisma';
+import prisma, { getChannelOffset } from '@/_utile/prisma';
 
 export const getChannel = async (offset: string): Promise<HikasenVtuber[]> => {
   const BASE_QUERY_COUNT = 20;
@@ -8,11 +8,7 @@ export const getChannel = async (offset: string): Promise<HikasenVtuber[]> => {
       ? ''
       : `?offset=${BASE_QUERY_COUNT * (Number(offset) - 1)}&limit=20`;
 
-  const res = await prisma.channel.findMany({
-    orderBy: {
-      isOfficial: 'desc',
-    },
-  });
+  const res = getChannelOffset();
 
   return res;
 };

--- a/app/channels/_lib/api/getChannel.ts
+++ b/app/channels/_lib/api/getChannel.ts
@@ -1,5 +1,5 @@
-import { fetchExtend } from '@/_utile/fetch';
 import { HikasenVtuber } from '@/(types)/';
+import prisma from '@/_utile/prisma';
 
 export const getChannel = async (offset: string): Promise<HikasenVtuber[]> => {
   const BASE_QUERY_COUNT = 20;
@@ -8,8 +8,11 @@ export const getChannel = async (offset: string): Promise<HikasenVtuber[]> => {
       ? ''
       : `?offset=${BASE_QUERY_COUNT * (Number(offset) - 1)}&limit=20`;
 
-  const URL = `${process.env.CHANNELLIST_URL}${query}`;
-  const data = await fetchExtend<HikasenVtuber[]>({ url: URL });
+  const res = await prisma.channel.findMany({
+    orderBy: {
+      isOfficial: 'desc',
+    },
+  });
 
-  return data;
+  return res;
 };

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -5,18 +5,16 @@ import { Pagination } from './_components/Pagination';
 import { ChannelPanel } from '@/channels/_components/ChannelPanel';
 import { ErrorBoundaryExtended } from '@/_components/ErrorBoundary';
 import { HikasenVtuber } from './(types)';
-import { fetchExtend } from './_utile/fetch';
+import prisma from './_utile/prisma';
 
 const getChannel = async (offset: string): Promise<HikasenVtuber[]> => {
-  const BASE_QUERY_COUNT = 20;
-  const query =
-    Number(offset) === 1
-      ? ''
-      : `?offset=${BASE_QUERY_COUNT * (Number(offset) - 1)}&limit=20`;
+  const res = await prisma.channel.findMany({
+    orderBy: {
+      isOfficial: 'desc',
+    },
+  });
 
-  const URL = `${process.env.CHANNELLIST_URL}${query}`;
-  const data = await fetchExtend<HikasenVtuber[]>({ url: URL, store: false });
-  return data;
+  return res;
 };
 
 export default async function Home() {

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -5,16 +5,10 @@ import { Pagination } from './_components/Pagination';
 import { ChannelPanel } from '@/channels/_components/ChannelPanel';
 import { ErrorBoundaryExtended } from '@/_components/ErrorBoundary';
 import { HikasenVtuber } from './(types)';
-import prisma from './_utile/prisma';
+import prisma, { getChannelOffset } from './_utile/prisma';
 
 const getChannel = async (offset: string): Promise<HikasenVtuber[]> => {
-  const res = await prisma.channel.findMany({
-    orderBy: {
-      isOfficial: 'desc',
-    },
-  });
-
-  return res;
+  return getChannelOffset();
 };
 
 export default async function Home() {

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "node-mocks-http": "^1.12.1",
     "postcss": "^8.4.19",
     "prettier": "^2.7.1",
-    "prisma": "latest",
+    "prisma": "^4.16.1",
     "sass": "^1.62.1",
     "vite": "^4.2.1",
     "vitest": "^0.24.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -885,10 +885,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@prisma/engines@npm:4.16.0":
-  version: 4.16.0
-  resolution: "@prisma/engines@npm:4.16.0"
-  checksum: 60ef1c3720720cf5a9d23f52c668669736716afd1862c4ac61e8ebcd3ca896e3453f80dfab77f3b68b001c5d499a895f28e54cc5025eae61878b40c1ec5d99c3
+"@prisma/engines@npm:4.16.1":
+  version: 4.16.1
+  resolution: "@prisma/engines@npm:4.16.1"
+  checksum: 7b8c1a9e20434edaa919fb24585ebff573c4ace787ea5a135dfefde3571ae31d3f0b0347397774c38be6d2e3fc0087d4e21a2720fe9f7a66ffd870e34377040f
   languageName: node
   linkType: hard
 
@@ -1458,7 +1458,7 @@ __metadata:
     node-mocks-http: ^1.12.1
     postcss: ^8.4.19
     prettier: ^2.7.1
-    prisma: latest
+    prisma: ^4.16.1
     react: 18.2.0
     react-dom: 18.2.0
     recoil: ^0.7.7
@@ -5636,15 +5636,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"prisma@npm:latest":
-  version: 4.16.0
-  resolution: "prisma@npm:4.16.0"
+"prisma@npm:^4.16.1":
+  version: 4.16.1
+  resolution: "prisma@npm:4.16.1"
   dependencies:
-    "@prisma/engines": 4.16.0
+    "@prisma/engines": 4.16.1
   bin:
     prisma: build/index.js
     prisma2: build/index.js
-  checksum: 831a4d14a48474fa144ae0648ed5e3766756b991f1997ecca813a044ef9bd7f2a5794c603adc9d23d867d8f4a0f51cedadaebfd8a841e6923ef9b804ed8bcbbb
+  checksum: eb0f43970464fbaa6ba190a714f23d00acd39dcc14fd8a7183dffc51a548cc32040cc5360415787578749862af7501a7bedcf9f2a0e64a3f82e3af402e9439d7
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Why

プロダクトで使用する値はDBのを優先するため、プロダクト全体でPrismaできるように設定が必要
チャンネル情報取得部分の処理をPrismaへ置換する

## What

Utilityとして、Prismaの宣言と設定部分をファイルとして切り出し
DBから取得するPrismaのロジック関数を切り出し、それを各部分で使用する