### PR TITLE
変更 - プロパティの値にフラグをいれればよいだけなので、IF文を削除

### DIFF
--- a/app/control/(hooks)/useAdminControl.ts
+++ b/app/control/(hooks)/useAdminControl.ts
@@ -64,11 +64,8 @@ const channelList = selector<ControlChannel[]>({
           isMatched = false;
         }
       });
-      if (isMatched) {
-        return { ...channel, isAllMatched: true };
-      } else {
-        return { ...channel, isAllMatched: false };
-      }
+
+      return { ...channel, isAllMatched: isMatched };
     });
     return channels;
   },


### PR DESCRIPTION
## Issue / Ticket

 - None

## Why

フラグ値により、ロジックの振る舞いを変えたいと思いIF文を使っていたが、フラグ値をそのまま代入すればよいとの指摘を頂いたので修正を行う
将来的に行いたかった機能も、そのまま値を代入すればよいだけと気づけたので、IF文は不要であると判断

## What

isMatchedを、オブジェクトのプロパティisAllMatchedへ直接指定

## Next Point

 - None
 
## 変更画面のサンプル

- None

## 参考資料

- None