### PR TITLE
反映 - ログアウト処理を追加/ログイン処理を管理者画面TOPページへ移動

### DIFF
--- a/app/control/_components/channelList.tsx
+++ b/app/control/_components/channelList.tsx
@@ -3,6 +3,7 @@
 import { Icon } from '@/_components/Elements/Icon';
 import styles from '@/control/_styles/channelList.module.scss';
 import { useAdminControl } from '@/control/(hooks)/useAdminControl';
+import { createClientComponentClient } from '@supabase/auth-helpers-nextjs';
 
 export const ChannelList = () => {
   const [channels, selectedChannels, selectedChannel, updateDataBase] =
@@ -11,15 +12,22 @@ export const ChannelList = () => {
     ? process.env.NEXT_PUBLIC_YOUTUBE_CHANNEL_ICON_URL
     : '';
 
+  const supabase = createClientComponentClient();
+
   const changeStyles = (isAllMatched: boolean): string => {
     if (isAllMatched)
       return `${styles.channel_sever} ${styles.channel_hasServer}`;
     return `${styles.channel_sever}`;
   };
+
+  const signOut = async () => {
+    await supabase.auth.signOut();
+  };
   return (
     <>
       {selectedChannels.length}件のチャンネルを更新予定
       <button onClick={() => updateDataBase()}>DBを更新する</button>
+      <button onClick={() => signOut()}>ログアウト</button>
       <ul>
         {channels.map((channel, index) => (
           <li className={styles.channels} key={index}>

--- a/app/control/_components/controlSignIn.tsx
+++ b/app/control/_components/controlSignIn.tsx
@@ -1,0 +1,11 @@
+'use client';
+
+import { SignIn } from '@/_components/Sign';
+
+export default function ControlSignIn() {
+  return (
+    <SignIn provider="github" param="?page=control&">
+      Sig In
+    </SignIn>
+  );
+}

--- a/app/control/page.tsx
+++ b/app/control/page.tsx
@@ -1,7 +1,8 @@
 import dynamic from 'next/dynamic';
 import { createServerComponentClient } from '@supabase/auth-helpers-nextjs';
 import { cookies } from 'next/headers';
-import Link from 'next/link';
+
+import ControlSignIn from '@/control/_components/controlSignIn';
 
 const DynamicControlClientComponent = dynamic(
   () => import('@/control/_components/channelControl'),
@@ -15,16 +16,19 @@ export default async function Index() {
 
   return (
     <div>
-      {data.user ? (
-        <DynamicControlClientComponent />
-      ) : (
-        <>
-          <div>
-            ログイン認証が必要なページです。ログイン認証を行ってください
-          </div>
-          <Link href={`/control/auth`}>認証ページへ</Link>
-        </>
-      )}
+      <div>
+        {/* ログインされていない場合は、ログイン画面への遷移を促す */}
+        {user ? (
+          <DynamicControlClientComponent isAdmin={isAdmin} />
+        ) : (
+          <>
+            <div>
+              ログイン認証が必要なページです。ログイン認証を行ってください
+            </div>
+            <ControlSignIn />
+          </>
+        )}
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## Issue / Ticket

[Trello - ログイン画面を作成](https://trello.com/c/h7NFD4Io/9-%E3%83%AD%E3%82%B0%E3%82%A4%E3%83%B3%E7%94%BB%E9%9D%A2%E3%82%92%E4%BD%9C%E6%88%90)
[Trello - SupaBaseのAuthを利用してGithubアカウントの承認](https://trello.com/c/0c102y00/10-supabase%E3%81%AEauth%E3%82%92%E5%88%A9%E7%94%A8%E3%81%97%E3%81%A6github%E3%82%A2%E3%82%AB%E3%82%A6%E3%83%B3%E3%83%88%E3%81%AE%E6%89%BF%E8%AA%8D)
## 課題/何が起こったか

ログインをしようして、認証で見れるはずのページが見れなかった

## 仮説/どうしてそうなったのか

ログイン処理が上手くいってなかった部分を、管理者TOPページからTOPページへ戻すのが原因だと思っていた
リダイレクトで管理者TOPページへ戻すために、別階層でログイン処理を行えばいいと考えていた
実際には、awaitの指定やcallbackの指定など設定が間違っていたため、階層を分ける必要性が不要だった
別階層にしたのを、管理者TOPページでログイン処理を行うようにする

## どういう作業を行ったか

SignInコンポーネントへ、必要な引数を与えるラッパーコンポーネントの[ControlSignIn.tsx]を作成
[control/page.tsx]でLinkコンポーネントでページ遷移を行っていた部分を、[ControlSignIn.tsx]のコンポーネントで置き換えをする

## Next Point

 - None

## 変更画面のサンプル

![cbcf1f65fac86e5ff699ab6f7ec7302f](https://github.com/OKAUEND/ffxiv_vtuber_archives/assets/38197580/bd141e33-be4f-4cc4-a967-3999258430d6)


## 参考資料
 - None
