### PR TITLE
反映 - 管理者権限の認証を行い、管理者のみアクセスを可能にする

### DIFF
--- a/app/control/_components/channelControl.tsx
+++ b/app/control/_components/channelControl.tsx
@@ -1,9 +1,30 @@
 'use client';
 
+import { createClientComponentClient } from '@supabase/auth-helpers-nextjs';
+import { useRouter } from 'next/navigation';
+
 import styles from '@/control/_styles/channelList.module.scss';
 import { ChannelList } from '@/control/_components/channelList';
 
-const ChannelControl = () => {
+interface IProps {
+  isAdmin: boolean;
+}
+
+const ChannelControl = ({ isAdmin }: IProps) => {
+  const router = useRouter();
+
+  //管理者以外でログインしている場合があるため、強制ログアウトを実行しログアウトさせる
+  const signOut = async () => {
+    const supabase = createClientComponentClient();
+    await supabase.auth.signOut();
+  };
+
+  //管理者以外はトップページへ強制的に遷移させ、アクセスさせない
+  if (!isAdmin) {
+    signOut();
+    router.push('/');
+  }
+
   return (
     <section className={styles.container}>
       <h2>配信者一覧</h2>

--- a/app/control/page.tsx
+++ b/app/control/page.tsx
@@ -9,10 +9,25 @@ const DynamicControlClientComponent = dynamic(
   { ssr: false }
 );
 
-export default async function Index() {
+/**
+ * ユーザー認証をサーバー側で行う
+ * @param cookies
+ * @returns user , boolean
+ */
+const getUserSession = async (cookies) => {
   const supabase = createServerComponentClient({ cookies });
+  const {
+    data: { session },
+  } = await supabase.auth.getSession();
+  const user = session?.user || null;
 
-  const { data } = await supabase.auth.getUser();
+  const isAdmin = session?.user.id === process.env.ADMIN_ID;
+
+  return [user, isAdmin] as const;
+};
+
+export default async function Index() {
+  const [user, isAdmin] = await getUserSession(cookies);
 
   return (
     <div>

--- a/env/types.d.ts
+++ b/env/types.d.ts
@@ -1,12 +1,13 @@
 type Env = Partial<Readonly<typeof import('./env.local.json')>>;
 
 declare namespace NodeJS {
-    interface ProcessEnv extends Env {
-        readonly NEXT_PUBLIC_HOST?: string;
-        readonly NEXT_PUBLIC_YOUTUBE_API?: string;
-        readonly NEXT_PUBLIC_YOUTUBE_API_URL?: string;
-        readonly NEXT_PUBLIC_CHANNELLIST_URL?: string;
-        readonly NEXT_PUBLIC_CHANNEL_ICON_URL?: string;
-        readonly NEXT_PUBLIC_TEST_DOMAIN?: string;
-    }
+  interface ProcessEnv extends Env {
+    readonly NEXT_PUBLIC_HOST?: string;
+    readonly NEXT_PUBLIC_YOUTUBE_API?: string;
+    readonly NEXT_PUBLIC_YOUTUBE_API_URL?: string;
+    readonly NEXT_PUBLIC_CHANNELLIST_URL?: string;
+    readonly NEXT_PUBLIC_CHANNEL_ICON_URL?: string;
+    readonly NEXT_PUBLIC_TEST_DOMAIN?: string;
+    readonly ADMIN_ID: string;
+  }
 }


### PR DESCRIPTION
## Issue / Ticket

[管理者画面でアカウント認証機能を実装](https://trello.com/c/83BhPjxu/11-%E7%AE%A1%E7%90%86%E8%80%85%E7%94%BB%E9%9D%A2%E3%81%A7%E3%82%A2%E3%82%AB%E3%82%A6%E3%83%B3%E3%83%88%E8%AA%8D%E8%A8%BC%E6%A9%9F%E8%83%BD%E3%82%92%E5%AE%9F%E8%A3%85)
[認証失敗ならトップページへ戻す](https://trello.com/c/s69cMikU/12-%E8%AA%8D%E8%A8%BC%E5%A4%B1%E6%95%97%E3%81%AA%E3%82%89%E3%83%88%E3%83%83%E3%83%97%E3%83%9A%E3%83%BC%E3%82%B8%E3%81%B8%E6%88%BB%E3%81%99)
## 課題/何が起こったか

ログインをしたユーザーなら誰でも管理者ページを閲覧できているため、セキュリティ上勝手に情報を操作される危険がある

## 仮説/どういう風にするか
管理者権限を持つもののみアクセスを可能にし、持たないものはTOPページへ強制リダイレクトさせ、閲覧をさせない
強制リダイレクトする理由は、閲覧できない旨の警告文を出すと管理者権限が必要などの情報が使用ユーザーにバレる可能性があるので、
強制リダイレクトさせることで、管理者権限などが必要であるとの情報を与えないようにする
強制リダイレクト時にログアウトさせるのは、管理者画面でのログイン認証をさせたくないから

## どういう作業を行ったか

管理者権限の認証は環境変数にUUIDを格納し、それとログインユーザーのUUIDを比較することで認証のロジックを作成
ServerComponentでは強制リダイレクトは実装できないので、ClientComponentでRouterを使いリダイレクトを実装
リダイレクト時に、ログイン状態を解除させるのは

## Next Point

- None

## 変更画面のサンプル

- None 

## 参考資料
[参考コード](https://github.com/qisarazu/iroha-fansite/blob/main/src/pages/admin/index.tsx)
