### PR TITLE
反映 - 管理者画面でもFFXIVの初配信日時を年月日にして、見やすくする

### DIFF
--- a/app/control/_components/channelList.tsx
+++ b/app/control/_components/channelList.tsx
@@ -4,6 +4,7 @@ import { Icon } from '@/_components/Elements/Icon';
 import styles from '@/control/_styles/channelList.module.scss';
 import { useAdminControl } from '@/control/(hooks)/useAdminControl';
 import { createClientComponentClient } from '@supabase/auth-helpers-nextjs';
+import DayTime from '@/_utile/convert/DayTime';
 
 export const ChannelList = () => {
   const [channels, selectedChannels, selectedChannel, updateDataBase] =
@@ -43,7 +44,7 @@ export const ChannelList = () => {
             <div className={styles.channel_info}>
               <h3 className={styles.title}>{channel.name}</h3>
               <span>{channel.channelName}</span>
-              <span>2013/8.13</span>
+              <span>{DayTime(channel.beginTime)}</span>
             </div>
             <div className={styles.channel_action}>
               <button onClick={() => selectedChannel(channel)}>追加する</button>


### PR DESCRIPTION
## Issue / Ticket

 - None

## Why

管理者ページでも初配信日の年月日を表示させ、いつから始めたのかを視覚的にわかりやすくする
以前は仮値で日数を入れていたのを、取得した値を使用する

## What

ユーザーが閲覧するページで使用してるDayTime関数を使用する

## Next Point

- None

## 変更画面のサンプル

![363c4ef54b5cca5ee78ca825799de2ea](https://github.com/OKAUEND/ffxiv_vtuber_archives/assets/38197580/36ea61bc-f852-4e62-af00-cc5d79ea3958)


## 参考資料

- None
