### PR TITLE
反映 - Prismaを使い配信者一覧のページネーションを実現する

### DIFF
--- a/app/_components/Pagination/__tests__/Pagination.test.tsx
+++ b/app/_components/Pagination/__tests__/Pagination.test.tsx
@@ -6,11 +6,11 @@ import { Pagination } from '..';
 describe('Pagination Component TEST', () => {
   const generateArray = (begin: number) => {
     const offsetNumber = begin - 2;
-    return [...Array(5)].map((_, index) => offsetNumber + index);
+    return [...Array(5)].map((_, index) => `${offsetNumber + index}`);
   };
 
   test('現在ページが1だった場合', () => {
-    render(<Pagination basePath="./" currentPageNumber={1} />);
+    render(<Pagination basePath="./" currentPageNumber={1} totalCount={100} />);
 
     const paginationItems = screen.getAllByRole('listitem');
     expect(paginationItems).toHaveLength(5);
@@ -20,42 +20,95 @@ describe('Pagination Component TEST', () => {
     expect(pageNumbers).toEqual(['1', '2', '3', '4', '5']);
   });
   test('現在ページが4だった場合', () => {
-    render(<Pagination basePath="./" currentPageNumber={4} />);
+    const list = ['1', '2', '3', '4', '5'];
+    render(<Pagination basePath="./" currentPageNumber={4} totalCount={100} />);
 
     const paginationItems = screen.getAllByRole('listitem');
     expect(paginationItems).toHaveLength(5);
 
-    // ページ番号のテキストを検証
-    ['1', '2', '3', '4', '5'].forEach((number) => {
-      expect(screen.getByText(number.toString()).textContent).toEqual(
-        number.toString()
-      );
-    });
+    const contentTexts = paginationItems.map((list) => list.textContent);
+
+    expect(contentTexts).toEqual(list);
   });
   test('現在ページが5だった場合', () => {
-    render(<Pagination basePath="./" currentPageNumber={5} />);
+    render(<Pagination basePath="./" currentPageNumber={5} totalCount={100} />);
 
     const paginationItems = screen.getAllByRole('listitem');
     expect(paginationItems).toHaveLength(5);
 
+    const contentTexts = paginationItems.map((list) => list.textContent);
+
     // ページ番号のテキストを検証
-    generateArray(5).forEach((number) => {
-      expect(screen.getByText(number.toString()).textContent).toEqual(
-        number.toString()
-      );
-    });
+    expect(contentTexts).toEqual(generateArray(5));
   });
   test('現在ページが10だった場合', () => {
-    render(<Pagination basePath="./" currentPageNumber={10} />);
+    render(
+      <Pagination basePath="./" currentPageNumber={10} totalCount={100} />
+    );
 
     const paginationItems = screen.getAllByRole('listitem');
     expect(paginationItems).toHaveLength(5);
 
+    const contentTexts = paginationItems.map((list) => list.textContent);
+
     // ページ番号のテキストを検証
-    generateArray(10).forEach((number) => {
-      expect(screen.getByText(number.toString()).textContent).toEqual(
-        number.toString()
-      );
-    });
+    expect(contentTexts).toEqual(generateArray(10));
+  });
+  test('トータル件数が20件だった場合、ページネーションのボタンは1つだけ表示されている', () => {
+    render(<Pagination basePath="./" currentPageNumber={1} totalCount={20} />);
+
+    const paginationItems = screen.getAllByRole('listitem');
+    expect(paginationItems).toHaveLength(1);
+
+    const contentTexts = paginationItems.map((list) => list.textContent);
+
+    // ページ番号のテキストを検証
+    expect(contentTexts).toEqual(['1']);
+  });
+  test('トータル件数が40件だった場合、ページネーションのボタンは2つだけ表示されている', () => {
+    render(<Pagination basePath="./" currentPageNumber={1} totalCount={40} />);
+
+    const paginationItems = screen.getAllByRole('listitem');
+    expect(paginationItems).toHaveLength(2);
+
+    const contentTexts = paginationItems.map((list) => list.textContent);
+
+    // ページ番号のテキストを検証
+    expect(contentTexts).toEqual(['1', '2']);
+  });
+  test('トータル件数が40件だった場合、ページネーションのボタンは2つだけ表示されている', () => {
+    render(<Pagination basePath="./" currentPageNumber={1} totalCount={80} />);
+
+    const paginationItems = screen.getAllByRole('listitem');
+    expect(paginationItems).toHaveLength(4);
+
+    const contentTexts = paginationItems.map((list) => list.textContent);
+
+    // ページ番号のテキストを検証
+    expect(contentTexts).toEqual(['1', '2', '3', '4']);
+  });
+
+  test('トータル件数が200件だった場合、ページネーションのボタンは5つだけ表示されている', () => {
+    render(<Pagination basePath="./" currentPageNumber={1} totalCount={200} />);
+
+    const paginationItems = screen.getAllByRole('listitem');
+    expect(paginationItems).toHaveLength(5);
+
+    const contentTexts = paginationItems.map((list) => list.textContent);
+
+    // ページ番号のテキストを検証
+    expect(contentTexts).toEqual(['1', '2', '3', '4', '5']);
+  });
+
+  test('トータル件数が75件の小数点が発生する場合、ページネーションのボタンは4つだけ表示されている', () => {
+    render(<Pagination basePath="./" currentPageNumber={1} totalCount={75} />);
+
+    const paginationItems = screen.getAllByRole('listitem');
+    expect(paginationItems).toHaveLength(4);
+
+    const contentTexts = paginationItems.map((list) => list.textContent);
+
+    // ページ番号のテキストを検証
+    expect(contentTexts).toEqual(['1', '2', '3', '4']);
   });
 });

--- a/app/_components/Pagination/index.tsx
+++ b/app/_components/Pagination/index.tsx
@@ -8,15 +8,46 @@ interface Props {
   // totalCount: number;
   basePath: string;
   currentPageNumber: number;
+  totalCount: number;
 }
 
-export const Pagination = ({ basePath, currentPageNumber = 1 }: Props) => {
-  const PER_PAGE = 5;
-  const offsetPageNumber =
-    currentPageNumber > PER_PAGE - 1 ? currentPageNumber - 2 : 1;
+const MAX_PAGE = 5;
+
+/**
+ * ページ番号の上限数を作成する(Max:5)
+ * @param totalCount
+ * @returns
+ */
+const createPageNumber = (totalCount: number) => {
+  const totalPageNumber = Math.ceil(totalCount / 20);
+  if (totalPageNumber > MAX_PAGE) return MAX_PAGE;
+
+  return totalPageNumber;
+};
+
+/**
+ * 遷移先のページ番号を生成する
+ * @param pageNumber
+ * @param currantNumber
+ * @returns
+ */
+const createOffsetNumber = (pageNumber: number, currantNumber: number) => {
+  //2以下は2つ分の以前のページ番号を表示する必要がないため、そのまま値を返す
+  if (pageNumber <= 2) return currantNumber;
+
+  return currantNumber > pageNumber - 1 ? currantNumber - 2 : 1;
+};
+
+export const Pagination = ({
+  basePath,
+  currentPageNumber = 1,
+  totalCount,
+}: Props) => {
+  const maxPage = createPageNumber(totalCount);
+  const offsetPageNumber = createOffsetNumber(maxPage, currentPageNumber);
 
   const paginationList = () =>
-    [...Array(PER_PAGE)].map((_, index) => offsetPageNumber + index);
+    [...Array(maxPage)].map((_, index) => offsetPageNumber + index);
 
   const toggleCurrantNumberStyle = (
     currantNumber: number,

--- a/app/_utile/prisma/index.ts
+++ b/app/_utile/prisma/index.ts
@@ -5,8 +5,12 @@ const prisma = new PrismaClient({
   log: ['query', 'error', 'info', 'warn'],
 });
 
-export const getChannelOffset = async (): Promise<HikasenVtuber[]> => {
+export const getChannelOffset = async (
+  offset = 0
+): Promise<HikasenVtuber[]> => {
   const res = await prisma.channel.findMany({
+    take: 20,
+    skip: offset,
     orderBy: [
       {
         isOfficial: 'desc',

--- a/app/_utile/prisma/index.ts
+++ b/app/_utile/prisma/index.ts
@@ -22,4 +22,9 @@ export const getChannelOffset = async (
   return res;
 };
 
+export const getChannelCount = async () => {
+  const res = await prisma.channel.count();
+  return res;
+};
+
 export default prisma;

--- a/app/channels/[pages]/page.tsx
+++ b/app/channels/[pages]/page.tsx
@@ -1,10 +1,14 @@
 import { Channel } from '@/channels/_components/router';
 
-export default async function Article() {
+export default async function Article({
+  params,
+}: {
+  params: { pages: string };
+}) {
   return (
     <>
       {/* @ts-expect-error Async Server Component */}
-      <Channel />
+      <Channel param={params.pages} />
     </>
   );
 }

--- a/app/channels/_components/router.tsx
+++ b/app/channels/_components/router.tsx
@@ -1,7 +1,11 @@
 import { getChannel } from '@/channels/_lib/api/getChannel';
 import { ChannelPanel } from '@/channels/_components/ChannelPanel';
 
-export const Channel = async () => {
-  const channels = await getChannel('1');
+interface IProps {
+  param: string;
+}
+
+export const Channel = async ({ param }: IProps) => {
+  const channels = await getChannel(param);
   return <ChannelPanel channels={channels} />;
 };

--- a/app/channels/_lib/api/getChannel.ts
+++ b/app/channels/_lib/api/getChannel.ts
@@ -9,9 +9,7 @@ export const getChannel = async (offset: string): Promise<HikasenVtuber[]> => {
 
   //ページ番号よりOffsetでずらす件数を作成し、+1することで、同じ要素の重複取得を防ぐ
   const skip =
-    offsetNumber > 1
-      ? offsetNumber
-      : BASE_QUERY_COUNT * (Number(offset) - 1) + 1;
+    offsetNumber === 1 ? 0 : BASE_QUERY_COUNT * (offsetNumber - 1) + 1;
 
   const res = getChannelOffset(skip);
 

--- a/app/channels/_lib/api/getChannel.ts
+++ b/app/channels/_lib/api/getChannel.ts
@@ -1,14 +1,19 @@
 import { HikasenVtuber } from '@/(types)/';
-import prisma, { getChannelOffset } from '@/_utile/prisma';
+import { getChannelOffset } from '@/_utile/prisma';
 
 export const getChannel = async (offset: string): Promise<HikasenVtuber[]> => {
+  //モバイルでのみやすさも考慮し、20件ほどに絞る。10件だけはPCやタブレットで見るには少なすぎる
   const BASE_QUERY_COUNT = 20;
-  const query =
-    Number(offset) === 1
-      ? ''
-      : `?offset=${BASE_QUERY_COUNT * (Number(offset) - 1)}&limit=20`;
+  //何も指定がないときのためのガード構文
+  const offsetNumber = offset ? Number(offset) : 1;
 
-  const res = getChannelOffset();
+  //ページ番号よりOffsetでずらす件数を作成し、+1することで、同じ要素の重複取得を防ぐ
+  const skip =
+    offsetNumber > 1
+      ? offsetNumber
+      : BASE_QUERY_COUNT * (Number(offset) - 1) + 1;
+
+  const res = getChannelOffset(skip);
 
   return res;
 };

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -15,13 +15,17 @@ const getChannel = async (): Promise<readonly [HikasenVtuber[], number]> => {
 };
 
 export default async function Home() {
-  const channels = await getChannel();
+  const [channels, totalCount] = await getChannel();
   return (
     <section className={styles.content}>
       <ErrorBoundaryExtended>
         <ChannelPanel channels={channels} />
 
-        <Pagination basePath="channels" currentPageNumber={1} />
+        <Pagination
+          basePath="channels"
+          currentPageNumber={1}
+          totalCount={totalCount}
+        />
       </ErrorBoundaryExtended>
     </section>
   );

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -5,10 +5,13 @@ import { Pagination } from './_components/Pagination';
 import { ChannelPanel } from '@/channels/_components/ChannelPanel';
 import { ErrorBoundaryExtended } from '@/_components/ErrorBoundary';
 import { HikasenVtuber } from './(types)';
-import { getChannelOffset } from './_utile/prisma';
+import { getChannelOffset, getChannelCount } from './_utile/prisma';
 
-const getChannel = async (): Promise<HikasenVtuber[]> => {
-  return getChannelOffset(0);
+const getChannel = async (): Promise<readonly [HikasenVtuber[], number]> => {
+  const channels = await getChannelOffset(0);
+  const count = await getChannelCount();
+
+  return [channels, count] as const;
 };
 
 export default async function Home() {

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -5,14 +5,14 @@ import { Pagination } from './_components/Pagination';
 import { ChannelPanel } from '@/channels/_components/ChannelPanel';
 import { ErrorBoundaryExtended } from '@/_components/ErrorBoundary';
 import { HikasenVtuber } from './(types)';
-import prisma, { getChannelOffset } from './_utile/prisma';
+import { getChannelOffset } from './_utile/prisma';
 
-const getChannel = async (offset: string): Promise<HikasenVtuber[]> => {
-  return getChannelOffset();
+const getChannel = async (): Promise<HikasenVtuber[]> => {
+  return getChannelOffset(0);
 };
 
 export default async function Home() {
-  const channels = await getChannel('1');
+  const channels = await getChannel();
   return (
     <section className={styles.content}>
       <ErrorBoundaryExtended>


### PR DESCRIPTION
## Issue / Ticket

 [Trello - 配信者一覧ページでのスプレッドシートより取得している処理をPrismaに置換し、ページネーションを実装する](https://trello.com/c/OGnIDXVU/22-%E9%85%8D%E4%BF%A1%E8%80%85%E4%B8%80%E8%A6%A7%E3%83%9A%E3%83%BC%E3%82%B8%E3%81%A7%E3%81%AE%E3%82%B9%E3%83%97%E3%83%AC%E3%83%83%E3%83%89%E3%82%B7%E3%83%BC%E3%83%88%E3%82%88%E3%82%8A%E5%8F%96%E5%BE%97%E3%81%97%E3%81%A6%E3%81%84%E3%82%8B%E5%87%A6%E7%90%86%E3%82%92prisma%E3%81%AB%E7%BD%AE%E6%8F%9B%E3%81%97%E3%80%81%E3%83%9A%E3%83%BC%E3%82%B8%E3%83%8D%E3%83%BC%E3%82%B7%E3%83%A7%E3%83%B3%E3%82%92%E5%AE%9F%E8%A3%85%E3%81%99%E3%82%8B)
 [Trello - ページネーションでは、２ページ目以降は別ページへ遷移](https://trello.com/c/vSfrkZzu/29-%E3%83%9A%E3%83%BC%E3%82%B8%E3%83%8D%E3%83%BC%E3%82%B7%E3%83%A7%E3%83%B3%E3%81%A7%E3%81%AF%E3%80%81%EF%BC%92%E3%83%9A%E3%83%BC%E3%82%B8%E7%9B%AE%E4%BB%A5%E9%99%8D%E3%81%AF%E5%88%A5%E3%83%9A%E3%83%BC%E3%82%B8%E3%81%B8%E9%81%B7%E7%A7%BB)
 [Trello - トータル件数から、ページネーション先の要素作成数を絞る](https://trello.com/c/y4YxqwUn/30-%E3%83%88%E3%83%BC%E3%82%BF%E3%83%AB%E4%BB%B6%E6%95%B0%E3%81%8B%E3%82%89%E3%80%81%E3%83%9A%E3%83%BC%E3%82%B8%E3%83%8D%E3%83%BC%E3%82%B7%E3%83%A7%E3%83%B3%E5%85%88%E3%81%AE%E8%A6%81%E7%B4%A0%E4%BD%9C%E6%88%90%E6%95%B0%E3%82%92%E7%B5%9E%E3%82%8B)

## Why

ページネーションの機能を準備段階として作ってあったので、Prismaの機能を使い本格的に実装する
TOPページや2ページ以降の配信者一覧は、条件抽出をしていないので表示速度を優先するためSSRで実現したいため
アーカイブ一覧の方は無限スクロールで実装したため、こちらはページネーションを技術的に試してみたかった

## What

PrismaのSkipとTakeを使い、次に取得する件数と開始インデックスをずらしていく。
2ページ以降はページ数をマイナス1し、一回に取得する件数を乗算することで、Skip数を算出する。
ページ数をマイナス1しないと、算出されたSkip数が多めに出てしまい、開始インデックスが飛んでしまうため。
(例:2(page) * 20(一回に取得する件数) = 40)
トータル件数を渡すことで、何ページ目までのボタンを表示するかの判別も行う

## Next Point

- ボタンの色味が暗いかもしれないので、白基調に変える検討もあり

## 変更画面のサンプル

![82ecf36bc4e251b938060a985bc398f5](https://github.com/OKAUEND/ffxiv_vtuber_archives/assets/38197580/8d84d9bf-ba3f-4625-9d97-4e8751b40326)

## 参考資料

- [Prisma - Pagination](https://www.prisma.io/docs/concepts/components/prisma-client/pagination)
- [参考にしたページネーションのボタンを表示する部分をロジック](https://www.tyai-a.com/posts/pagination-js)
