### PR TITLE
反映 - DBへの登録状態毎に、配信者リストを切り替える

### DIFF
--- a/app/_components/RadioList/RadioList.tsx
+++ b/app/_components/RadioList/RadioList.tsx
@@ -2,6 +2,39 @@
 
 import styles from './radios.module.scss';
 
-export const RadioList = () => {
-  return <div></div>;
+interface Props {
+  categories: string[];
+  selected: string;
+  group: string;
+  changeHandler: (selected: string) => void;
+}
+
+export const RadioList = ({
+  categories,
+  selected,
+  group,
+  changeHandler,
+}: Props) => {
+  const onChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    changeHandler(event.target.value);
+  };
+  return (
+    <ul className={styles.radio_container}>
+      {categories.map((category, index) => (
+        <li key={index} className={styles.radio_list}>
+          <label className={styles.radio_group}>
+            <input
+              className={styles.radio}
+              type="radio"
+              value={category}
+              name={group}
+              checked={selected === category}
+              onChange={onChange}
+            />
+            <span className={styles.radio_text}> {category}</span>
+          </label>
+        </li>
+      ))}
+    </ul>
+  );
 };

--- a/app/_components/RadioList/RadioList.tsx
+++ b/app/_components/RadioList/RadioList.tsx
@@ -1,0 +1,7 @@
+'use client';
+
+import styles from './radios.module.scss';
+
+export const RadioList = () => {
+  return <div></div>;
+};

--- a/app/_components/RadioList/RadioList.tsx
+++ b/app/_components/RadioList/RadioList.tsx
@@ -18,11 +18,15 @@ export const RadioList = ({
   const onChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     changeHandler(event.target.value);
   };
+
+  const checkedStyle = (target: string) => {
+    return selected === target ? styles.checked : '';
+  };
   return (
-    <ul className={styles.radio_container}>
+    <ul className={styles.container}>
       {categories.map((category, index) => (
-        <li key={index} className={styles.radio_list}>
-          <label className={styles.radio_group}>
+        <li key={index} className={styles.list}>
+          <label className={`${styles.radio_group} ${checkedStyle(category)}`}>
             <input
               className={styles.radio}
               type="radio"
@@ -31,7 +35,7 @@ export const RadioList = ({
               checked={selected === category}
               onChange={onChange}
             />
-            <span className={styles.radio_text}> {category}</span>
+            <span> {category}</span>
           </label>
         </li>
       ))}

--- a/app/_components/RadioList/index.tsx
+++ b/app/_components/RadioList/index.tsx
@@ -1,0 +1,1 @@
+export { RadioList } from './RadioList';

--- a/app/_components/RadioList/radios.module.scss
+++ b/app/_components/RadioList/radios.module.scss
@@ -1,0 +1,2 @@
+.container {
+}

--- a/app/_components/RadioList/radios.module.scss
+++ b/app/_components/RadioList/radios.module.scss
@@ -1,2 +1,33 @@
+@use '@/_styles/variables/variables.scss';
+
 .container {
+  list-style: none;
+  display: flex;
+  align-items: center;
+}
+
+.list {
+  width: 120px;
+
+  margin: 5px;
+}
+
+.radio_group {
+  display: inline-block;
+  width: 100%;
+  text-align: center;
+  padding: 5px;
+}
+
+.checked {
+  background-color: rgb(0, 0, 172);
+  border-radius: 5px;
+  color: variables.$text_color;
+  transition: all 0.2s;
+}
+
+.radio {
+  opacity: 0;
+  position: fixed;
+  width: 0;
 }

--- a/app/control/(hooks)/useAdminControl.ts
+++ b/app/control/(hooks)/useAdminControl.ts
@@ -1,16 +1,11 @@
 import { atom, selector, useRecoilValue, useRecoilCallback } from 'recoil';
 
 import { fetchExtend } from '@/_utile/fetch';
-import { Channels } from '@/control/(types)';
+import { Channels, FilterOption } from '@/control/(types)';
 import { HikasenVtuber } from '@/(types)';
 import { useCallback } from 'react';
 
 type ControlChannel = HikasenVtuber & { isAllMatched: boolean };
-
-/**
- * フィルタリング対象の状態
- */
-type FilterOption = 'all' | 'Match' | 'UnRegister';
 
 const updateChannel = async (channels: HikasenVtuber[]) => {
   const res = await fetchExtend({

--- a/app/control/(hooks)/useAdminControl.ts
+++ b/app/control/(hooks)/useAdminControl.ts
@@ -7,6 +7,11 @@ import { useCallback } from 'react';
 
 type ControlChannel = HikasenVtuber & { isAllMatched: boolean };
 
+/**
+ * フィルタリング対象の状態
+ */
+type FilterOption = 'all' | 'Match' | 'UnRegister';
+
 const updateChannel = async (channels: HikasenVtuber[]) => {
   const res = await fetchExtend({
     method: 'POST',
@@ -19,6 +24,14 @@ const updateChannel = async (channels: HikasenVtuber[]) => {
 const selectedChannel = atom<Map<string, HikasenVtuber>>({
   key: 'store/selected-channel',
   default: new Map([]),
+});
+
+/**
+ * DBの情報とのマッチ状態でフィルタリングをする対象を管理する
+ */
+const filterOption = atom<FilterOption>({
+  key: 'state/filer-option',
+  default: 'all',
 });
 
 const channelQuery = selector({
@@ -106,4 +119,19 @@ export const useAdminControl = () => {
   }, [selectedChannels]);
 
   return [channels, selectedChannels, cacheChannel, updateDataBase] as const;
+};
+
+/**
+ * このHookは登録状況によって表示内容を絞るための状態を管理するために使用します。
+ * @returns
+ */
+export const useFilterOption = () => {
+  const option = useRecoilValue(filterOption);
+  const changeFilterOption = useRecoilCallback(
+    ({ set }) =>
+      (option: FilterOption) => {
+        set(filterOption, option);
+      }
+  );
+  return [option, changeFilterOption] as const;
 };

--- a/app/control/(hooks)/useAdminControl.ts
+++ b/app/control/(hooks)/useAdminControl.ts
@@ -53,9 +53,9 @@ export const channelMapToArray = selector<HikasenVtuber[]>({
   },
 });
 
-const channelList = selector<ControlChannel[]>({
-  key: 'data-flow/channels-list',
-  get: async ({ get }) => {
+const channelFormatted = selector<ControlChannel[]>({
+  key: 'format/channel-register',
+  get: ({ get }) => {
     const data = get(channelQuery);
     const channels = data.gas.map((channel) => {
       //ここで、chennelと同じIDを持つのをdata.dbから取り出し、対象が存在するかを判定する
@@ -81,6 +81,22 @@ const channelList = selector<ControlChannel[]>({
       return { ...channel, isAllMatched: isMatched };
     });
     return channels;
+  },
+});
+
+const channelList = selector<ControlChannel[]>({
+  key: 'data-flow/channels-list',
+  get: async ({ get }) => {
+    const formattedChannel = get(channelFormatted);
+    const option = get(filterOption);
+    //管理画面で、配信者のDBへの登録状態毎にフィルタリングをし、一括確認を可能にする
+    const filterChannel = formattedChannel.filter((channel) => {
+      if (option === 'Match' && channel.isAllMatched) return channel;
+      if (option === 'UnRegister' && !channel.isAllMatched) return channel;
+      return channel;
+    });
+
+    return filterChannel;
   },
 });
 

--- a/app/control/(hooks)/useAdminControl.ts
+++ b/app/control/(hooks)/useAdminControl.ts
@@ -86,9 +86,18 @@ const channelList = selector<ControlChannel[]>({
     const option = get(filterOption);
     //管理画面で、配信者のDBへの登録状態毎にフィルタリングをし、一括確認を可能にする
     const filterChannel = formattedChannel.filter((channel) => {
-      if (option === 'Match' && channel.isAllMatched) return channel;
-      if (option === 'UnRegister' && !channel.isAllMatched) return channel;
-      return channel;
+      switch (option) {
+        case 'all':
+          return channel;
+        case 'Match':
+          if (channel.isAllMatched) return channel;
+          break;
+        case 'UnRegister':
+          if (!channel.isAllMatched) return channel;
+          break;
+        default:
+          break;
+      }
     });
 
     return filterChannel;

--- a/app/control/(types)/index.ts
+++ b/app/control/(types)/index.ts
@@ -4,3 +4,8 @@ export interface Channels {
   gas: HikasenVtuber[];
   db: HikasenVtuber[];
 }
+
+/**
+ * フィルタリング対象の状態
+ */
+export type FilterOption = 'all' | 'Match' | 'UnRegister';

--- a/app/control/_components/channelList.tsx
+++ b/app/control/_components/channelList.tsx
@@ -6,6 +6,8 @@ import { useAdminControl } from '@/control/(hooks)/useAdminControl';
 import { createClientComponentClient } from '@supabase/auth-helpers-nextjs';
 import DayTime from '@/_utile/convert/DayTime';
 
+import { MatchFilter } from '@/control/_components/channels/MatchFilter';
+
 export const ChannelList = () => {
   const [channels, selectedChannels, selectedChannel, updateDataBase] =
     useAdminControl();
@@ -29,6 +31,7 @@ export const ChannelList = () => {
       {selectedChannels.length}件のチャンネルを更新予定
       <button onClick={() => updateDataBase()}>DBを更新する</button>
       <button onClick={() => signOut()}>ログアウト</button>
+      <MatchFilter />
       <ul>
         {channels.map((channel, index) => (
           <li className={styles.channels} key={index}>

--- a/app/control/_components/channels/MatchFilter.tsx
+++ b/app/control/_components/channels/MatchFilter.tsx
@@ -1,0 +1,19 @@
+import { RadioList } from '@/_components/RadioList';
+import { useFilterOption } from '@/control/(hooks)/useAdminControl';
+
+import { FilterOption } from '@/control/(types)';
+
+const option: FilterOption[] = ['all', 'Match', 'UnRegister'];
+
+export const MatchFilter = () => {
+  const [matchLevel, changeFilterOption] = useFilterOption();
+
+  return (
+    <RadioList
+      categories={option}
+      selected={matchLevel}
+      group="match"
+      changeHandler={changeFilterOption}
+    />
+  );
+};


### PR DESCRIPTION
## Issue / Ticket

 [Trello - 未登録だけを表示できるようにフィルタリングを実装する](https://trello.com/c/iWutkgvL/23-%E6%9C%AA%E7%99%BB%E9%8C%B2%E3%81%A0%E3%81%91%E3%82%92%E8%A1%A8%E7%A4%BA%E3%81%A7%E3%81%8D%E3%82%8B%E3%82%88%E3%81%86%E3%81%AB%E3%83%95%E3%82%A3%E3%83%AB%E3%82%BF%E3%83%AA%E3%83%B3%E3%82%B0%E3%82%92%E5%AE%9F%E8%A3%85%E3%81%99%E3%82%8B)
 [Trello - 登録済み、未登録をフラグ値をつかいフィルタリングで実現](https://trello.com/c/sULXRLeQ/26-%E7%99%BB%E9%8C%B2%E6%B8%88%E3%81%BF%E3%80%81%E6%9C%AA%E7%99%BB%E9%8C%B2%E3%82%92%E3%83%95%E3%83%A9%E3%82%B0%E5%80%A4%E3%82%92%E3%81%A4%E3%81%8B%E3%81%84%E3%83%95%E3%82%A3%E3%83%AB%E3%82%BF%E3%83%AA%E3%83%B3%E3%82%B0%E3%81%A7%E5%AE%9F%E7%8F%BE)

## Why

管理者画面でDBへ全部/登録済み/未登録毎に◯✕の表記はしているが、50人60人規模になると目探しでは解りにくい。
なぜ未登録の配信者がいるかといえば、まだ登録基準に満たしていないゲーム進行の配信者を事前に登録しているから。
なぜ登録しているかといえば、一度補足したユーザーを見失わないように、その時点で登録をしているから
チャンネル登録などはしているが、Youtubeのぺージ上では誰が対象の配信者か解らなくなるので、時間が経つと忘れてしまうので、その場で対象になりそうな配信者を登録している。
そういった、まだ本登録はしていないが、事前登録の配信者を誰か判別するためにフィルタリング機能が必要

## What

配列のfilterメソッドを使い、登録状態を確認することで対象者をフィルタリングを行うことで表示を動的に変更する
また、UIで登録状態によって切り替えができるようにラジオボタンによって設定を可能にする

## Next Point

- ラジオボタンのテキストは内部データをそのまま使っているんで、もうちょっと分かり易い日本語にすべきかも

## 変更画面のサンプル

![21fc554cb584f10b4e14387890c0e9ef](https://github.com/OKAUEND/ffxiv_vtuber_archives/assets/38197580/b9b9bca1-0afd-42d2-9ecf-07974a380b75)
![db3b7f5c9d415eaecd7150714b1aea11](https://github.com/OKAUEND/ffxiv_vtuber_archives/assets/38197580/bef90354-ff6a-4633-8025-be405dcd63aa)


## 参考資料

- None
