### PR TITLE
反映 - 配信者を検索する機能を追加するため、ルートと画面を作成する

### DIFF
--- a/app/_components/RadioList/RadioList.tsx
+++ b/app/_components/RadioList/RadioList.tsx
@@ -11,7 +11,7 @@ interface Props {
   categories: Categories[];
   selected: string;
   group: string;
-  changeHandler: (selected: string) => void;
+  changeHandler: (selected: Categories) => void;
 }
 
 export const RadioList = ({
@@ -20,8 +20,8 @@ export const RadioList = ({
   group,
   changeHandler,
 }: Props) => {
-  const onChange = (event: React.ChangeEvent<HTMLInputElement>) => {
-    changeHandler(event.target.value);
+  const onChange = (category: Categories) => {
+    changeHandler(category);
   };
 
   const checkedStyle = (target: string) => {
@@ -40,7 +40,7 @@ export const RadioList = ({
               value={category.key}
               name={group}
               checked={selected === category.key}
-              onChange={onChange}
+              onChange={() => onChange(category)}
             />
             <span>{category.name}</span>
           </label>

--- a/app/_components/RadioList/RadioList.tsx
+++ b/app/_components/RadioList/RadioList.tsx
@@ -2,8 +2,13 @@
 
 import styles from './radios.module.scss';
 
+export interface Categories {
+  key: string;
+  name: string;
+}
+
 interface Props {
-  categories: string[];
+  categories: Categories[];
   selected: string;
   group: string;
   changeHandler: (selected: string) => void;
@@ -26,16 +31,18 @@ export const RadioList = ({
     <ul className={styles.container}>
       {categories.map((category, index) => (
         <li key={index} className={styles.list}>
-          <label className={`${styles.radio_group} ${checkedStyle(category)}`}>
+          <label
+            className={`${styles.radio_group} ${checkedStyle(category.key)}`}
+          >
             <input
               className={styles.radio}
               type="radio"
-              value={category}
+              value={category.key}
               name={group}
-              checked={selected === category}
+              checked={selected === category.key}
               onChange={onChange}
             />
-            <span>{category}</span>
+            <span>{category.name}</span>
           </label>
         </li>
       ))}

--- a/app/_components/RadioList/radios.module.scss
+++ b/app/_components/RadioList/radios.module.scss
@@ -4,6 +4,8 @@
   list-style: none;
   display: flex;
   align-items: center;
+  padding: 0;
+  margin: 0;
 }
 
 .list {

--- a/app/channels/(hooks)/Search/useChannelSearchOption.ts
+++ b/app/channels/(hooks)/Search/useChannelSearchOption.ts
@@ -1,8 +1,16 @@
+import { atom, useRecoilValue } from 'recoil';
+
 export const sortOptions = [
   { key: 'Desc', name: '新しい順' },
   { key: 'Asc', name: '古い順' },
 ];
 
+const sortOption = atom({
+  key: 'state/sort-option',
+  default: sortOptions[0],
+});
+
 export const useChannelSearchOption = () => {
-  return [] as const;
+  const option = useRecoilValue(sortOption);
+  return [option] as const;
 };

--- a/app/channels/(hooks)/Search/useChannelSearchOption.ts
+++ b/app/channels/(hooks)/Search/useChannelSearchOption.ts
@@ -1,0 +1,8 @@
+export const sortOptions = [
+  { key: 'Desc', name: '新しい順' },
+  { key: 'Asc', name: '古い順' },
+];
+
+export const useChannelSearchOption = () => {
+  return [] as const;
+};

--- a/app/channels/(hooks)/Search/useChannelSearchOption.ts
+++ b/app/channels/(hooks)/Search/useChannelSearchOption.ts
@@ -1,4 +1,4 @@
-import { atom, useRecoilValue } from 'recoil';
+import { atom, useRecoilCallback, useRecoilValue } from 'recoil';
 
 export const sortOptions = [
   { key: 'Desc', name: '新しい順' },
@@ -12,5 +12,9 @@ const sortOption = atom({
 
 export const useChannelSearchOption = () => {
   const option = useRecoilValue(sortOption);
-  return [option] as const;
+
+  const changeOption = useRecoilCallback(({ set }) => (option) => {
+    set(sortOption, option);
+  });
+  return [option, changeOption] as const;
 };

--- a/app/channels/_components/Search/SearchCategories.tsx
+++ b/app/channels/_components/Search/SearchCategories.tsx
@@ -1,0 +1,5 @@
+'use client';
+
+export const SearchCategories = () => {
+  return <div></div>;
+};

--- a/app/channels/_components/Search/SearchOption.tsx
+++ b/app/channels/_components/Search/SearchOption.tsx
@@ -1,5 +1,7 @@
 'use client';
 
+import { RadioList } from '@/_components/RadioList';
+
 import {
   useChannelSearchOption,
   sortOptions,
@@ -7,5 +9,19 @@ import {
 
 export const SearchOption = () => {
   const [] = useChannelSearchOption();
-  return <div></div>;
+  return (
+    <section>
+      <h2>絞り込み</h2>
+      <article>
+        <RadioList
+          categories={sortOptions}
+          selected="Desc"
+          group="Sort"
+          changeHandler={() => {
+            return;
+          }}
+        />
+      </article>
+    </section>
+  );
 };

--- a/app/channels/_components/Search/SearchOption.tsx
+++ b/app/channels/_components/Search/SearchOption.tsx
@@ -8,14 +8,14 @@ import {
 } from '@/channels/(hooks)/Search/useChannelSearchOption';
 
 export const SearchOption = () => {
-  const [] = useChannelSearchOption();
+  const [selectedOption] = useChannelSearchOption();
   return (
     <section>
       <h2>絞り込み</h2>
       <article>
         <RadioList
           categories={sortOptions}
-          selected="Desc"
+          selected={selectedOption.key}
           group="Sort"
           changeHandler={() => {
             return;

--- a/app/channels/_components/Search/SearchOption.tsx
+++ b/app/channels/_components/Search/SearchOption.tsx
@@ -8,7 +8,7 @@ import {
 } from '@/channels/(hooks)/Search/useChannelSearchOption';
 
 export const SearchOption = () => {
-  const [selectedOption] = useChannelSearchOption();
+  const [selectedOption, changeOption] = useChannelSearchOption();
   return (
     <section>
       <h2>絞り込み</h2>
@@ -17,9 +17,7 @@ export const SearchOption = () => {
           categories={sortOptions}
           selected={selectedOption.key}
           group="Sort"
-          changeHandler={() => {
-            return;
-          }}
+          changeHandler={changeOption}
         />
       </article>
     </section>

--- a/app/channels/_components/Search/SearchOption.tsx
+++ b/app/channels/_components/Search/SearchOption.tsx
@@ -1,5 +1,11 @@
 'use client';
 
+import {
+  useChannelSearchOption,
+  sortOptions,
+} from '@/channels/(hooks)/Search/useChannelSearchOption';
+
 export const SearchOption = () => {
+  const [] = useChannelSearchOption();
   return <div></div>;
 };

--- a/app/channels/_components/Search/SearchOption.tsx
+++ b/app/channels/_components/Search/SearchOption.tsx
@@ -13,6 +13,7 @@ export const SearchOption = () => {
     <section>
       <h2>絞り込み</h2>
       <article>
+        <span>並び</span>
         <RadioList
           categories={sortOptions}
           selected={selectedOption.key}

--- a/app/channels/_components/Search/SearchOption.tsx
+++ b/app/channels/_components/Search/SearchOption.tsx
@@ -1,0 +1,5 @@
+'use client';
+
+export const SearchOption = () => {
+  return <div></div>;
+};

--- a/app/channels/result/page.tsx
+++ b/app/channels/result/page.tsx
@@ -1,0 +1,7 @@
+export default async function ChannelResultIndex({
+  params,
+}: {
+  params: { query: string };
+}) {
+  return <></>;
+}

--- a/app/channels/search/page.tsx
+++ b/app/channels/search/page.tsx
@@ -1,0 +1,3 @@
+export default async function ChannelSearchIndex() {
+  return <></>;
+}

--- a/app/channels/search/page.tsx
+++ b/app/channels/search/page.tsx
@@ -1,3 +1,11 @@
+import { SearchOption } from '@/channels/_components/Search/SearchOption';
+import { SearchCategories } from '@/channels/_components/Search/SearchCategories';
+
 export default async function ChannelSearchIndex() {
-  return <></>;
+  return (
+    <>
+      <SearchOption />
+      <SearchCategories />
+    </>
+  );
 }

--- a/app/control/(types)/index.ts
+++ b/app/control/(types)/index.ts
@@ -8,4 +8,4 @@ export interface Channels {
 /**
  * フィルタリング対象の状態
  */
-export type FilterOption = 'all' | 'Match' | 'UnRegister';
+export type FilterOption = 'All' | 'Match' | 'UnRegister';

--- a/app/control/_components/channels/MatchFilter.tsx
+++ b/app/control/_components/channels/MatchFilter.tsx
@@ -3,7 +3,16 @@ import { useFilterOption } from '@/control/(hooks)/useAdminControl';
 
 import { FilterOption } from '@/control/(types)';
 
-const option: FilterOption[] = ['all', 'Match', 'UnRegister'];
+interface Option {
+  key: FilterOption;
+  name: string;
+}
+
+const option: Option[] = [
+  { key: 'All', name: '全て' },
+  { key: 'Match', name: '登録済み' },
+  { key: 'UnRegister', name: '未登録' },
+];
 
 export const MatchFilter = () => {
   const [matchLevel, changeFilterOption] = useFilterOption();


### PR DESCRIPTION
## Issue / Ticket

### 作業カテゴリー

[Trello - 機能 - 配信者の名前や配信日の降順昇順、配信年でフィルタリングをし、簡易検索機能を実現する](https://trello.com/c/Xch6WvPQ/45-%E6%A9%9F%E8%83%BD-%E9%85%8D%E4%BF%A1%E8%80%85%E3%81%AE%E5%90%8D%E5%89%8D%E3%82%84%E9%85%8D%E4%BF%A1%E6%97%A5%E3%81%AE%E9%99%8D%E9%A0%86%E6%98%87%E9%A0%86%E3%80%81%E9%85%8D%E4%BF%A1%E5%B9%B4%E3%81%A7%E3%83%95%E3%82%A3%E3%83%AB%E3%82%BF%E3%83%AA%E3%83%B3%E3%82%B0%E3%82%92%E3%81%97%E3%80%81%E7%B0%A1%E6%98%93%E6%A4%9C%E7%B4%A2%E6%A9%9F%E8%83%BD%E3%82%92%E5%AE%9F%E7%8F%BE%E3%81%99%E3%82%8B)

### 作業チケット

[Trello - 新しいRouteフォルダを作成する。channel/search](https://trello.com/c/KCgO2Ejz/47-%E6%96%B0%E3%81%97%E3%81%84route%E3%83%95%E3%82%A9%E3%83%AB%E3%83%80%E3%82%92%E4%BD%9C%E6%88%90%E3%81%99%E3%82%8B%E3%80%82channel-search)
[Trello - 新しいRouteフォルダを作成する。channel/result](https://trello.com/c/iWkvT72i/53-%E6%96%B0%E3%81%97%E3%81%84route%E3%83%95%E3%82%A9%E3%83%AB%E3%83%80%E3%82%92%E4%BD%9C%E6%88%90%E3%81%99%E3%82%8B%E3%80%82channel-result)
[Trello - channel/search/にpage.tsxを作成し、ルーティングでアクセス可能にする](https://trello.com/c/hNBNS826/48-channel-search-%E3%81%ABpagetsx%E3%82%92%E4%BD%9C%E6%88%90%E3%81%97%E3%80%81%E3%83%AB%E3%83%BC%E3%83%86%E3%82%A3%E3%83%B3%E3%82%B0%E3%81%A7%E3%82%A2%E3%82%AF%E3%82%BB%E3%82%B9%E5%8F%AF%E8%83%BD%E3%81%AB%E3%81%99%E3%82%8B)
[Trello - channel/resultにpage.tsxを作成し、ルーティングでアクセス可能にする](https://trello.com/c/iz5CZxzV/54-channel-result%E3%81%ABpagetsx%E3%82%92%E4%BD%9C%E6%88%90%E3%81%97%E3%80%81%E3%83%AB%E3%83%BC%E3%83%86%E3%82%A3%E3%83%B3%E3%82%B0%E3%81%A7%E3%82%A2%E3%82%AF%E3%82%BB%E3%82%B9%E5%8F%AF%E8%83%BD%E3%81%AB%E3%81%99%E3%82%8B)

## 課題/何が起こったか

配信者一覧で表示される配信者が多く、中程のページを1個づつ見ていくのがクリック数が多くめんどくさい

## 仮説/どうしてそうなったのか

配信者が現状で60名、登録予定の配信者で100名以上いるため、今以上にページネーションのページ数が増えると予想
予定している #97 で、Twitch専門で配信している人もいるため、その方々を含めると200名以上になる
200名からよさそうな配信者を探すのは、作業数が多くユーザーが途中で離脱する、
もしくは最初の方に表示された配信者で妥協し、奥の方に配置されている配信者までたどり着かない。

## どういう作業を行ったか

まずは事前準備として、検索操作画面と検索結果画面を用意する。
検索操作画面では、カテゴリー検索や絞り込み方法などを指定する。
検索結果画面では、検索結果をページネーションで表示する。
更に、検索操作画面で絞り込み操作のプロトタイプとして昇順降順の切り替えをラジオボタンを配置する


## Next Point

 - None

## 変更画面のサンプル
(今回は新規画面作成なので、変更前画面は存在しない)
![0030306f9693460bed6cb6cb2fa31f0a](https://github.com/OKAUEND/ffxiv_vtuber_archives/assets/38197580/86761e4e-7f79-4100-adf0-9d8a20e80f3b)

![b52d0f0e449fb729981e28e04195bd74](https://github.com/OKAUEND/ffxiv_vtuber_archives/assets/38197580/1a03f22c-72a9-4380-93c7-541754c061f8)


## 参考資料
 - None
