### PR TITLE
反映 - 2022年開始や2021年開始など、年毎に配信を開始した配信者を絞り込めるようにする。

### DIFF
--- a/app/channels/_components/Search/SearchCategories.tsx
+++ b/app/channels/_components/Search/SearchCategories.tsx
@@ -1,5 +1,9 @@
 'use client';
 
 export const SearchCategories = () => {
-  return <div></div>;
+  return (
+    <section>
+      <h2>カテゴリー検索</h2>
+    </section>
+  );
 };

--- a/app/channels/_components/Search/SearchCategories.tsx
+++ b/app/channels/_components/Search/SearchCategories.tsx
@@ -1,9 +1,28 @@
 'use client';
 
+import Link from 'next/link';
+
+const beginLiveYears = [
+  { key: '2018', name: '2018年' },
+  { key: '2019', name: '2019年' },
+  { key: '2020', name: '2020年' },
+  { key: '2021', name: '2021年' },
+];
+
 export const SearchCategories = () => {
   return (
     <section>
       <h2>カテゴリー検索</h2>
+      <article>
+        <span>配信開始年</span>
+        <ul>
+          {beginLiveYears.map((year) => (
+            <li key={year.key}>
+              <Link href={'/channels/result'}>{year.name}</Link>
+            </li>
+          ))}
+        </ul>
+      </article>
     </section>
   );
 };


### PR DESCRIPTION
# Issue / Ticket

### 作業カテゴリー

[Trello - 機能 - 配信者の名前や配信日の降順昇順、配信年でフィルタリングをし、簡易検索機能を実現する](https://trello.com/c/Xch6WvPQ/45-%E6%A9%9F%E8%83%BD-%E9%85%8D%E4%BF%A1%E8%80%85%E3%81%AE%E5%90%8D%E5%89%8D%E3%82%84%E9%85%8D%E4%BF%A1%E6%97%A5%E3%81%AE%E9%99%8D%E9%A0%86%E6%98%87%E9%A0%86%E3%80%81%E9%85%8D%E4%BF%A1%E5%B9%B4%E3%81%A7%E3%83%95%E3%82%A3%E3%83%AB%E3%82%BF%E3%83%AA%E3%83%B3%E3%82%B0%E3%82%92%E3%81%97%E3%80%81%E7%B0%A1%E6%98%93%E6%A4%9C%E7%B4%A2%E6%A9%9F%E8%83%BD%E3%82%92%E5%AE%9F%E7%8F%BE%E3%81%99%E3%82%8B)

### 作業チケット

[Trello - 2022年開始や2021年開始など、年毎に配信を開始した配信者を絞り込めるようにする。](https://trello.com/c/vbhz83S5/51-2022%E5%B9%B4%E9%96%8B%E5%A7%8B%E3%82%842021%E5%B9%B4%E9%96%8B%E5%A7%8B%E3%81%AA%E3%81%A9%E3%80%81%E5%B9%B4%E6%AF%8E%E3%81%AB%E9%85%8D%E4%BF%A1%E3%82%92%E9%96%8B%E5%A7%8B%E3%81%97%E3%81%9F%E9%85%8D%E4%BF%A1%E8%80%85%E3%82%92%E7%B5%9E%E3%82%8A%E8%BE%BC%E3%82%81%E3%82%8B%E3%82%88%E3%81%86%E3%81%AB%E3%81%99%E3%82%8B%E3%80%82)
[Trello - 検索画面をワイヤーフレームを元に構築する](https://trello.com/c/JLufTDuu/52-%E6%A4%9C%E7%B4%A2%E7%94%BB%E9%9D%A2%E3%82%92%E3%83%AF%E3%82%A4%E3%83%A4%E3%83%BC%E3%83%95%E3%83%AC%E3%83%BC%E3%83%A0%E3%82%92%E5%85%83%E3%81%AB%E6%A7%8B%E7%AF%89%E3%81%99%E3%82%8B)

## 課題/何が起こったか

配信者一覧で表示される配信者が多く、複数ページの中から配信者を探すには操作数が多くとても面倒
ユーザーが途中で断念する可能性があるので、検索で絞り込みを行う

## 仮説/どうしてそうなったのか

配信者が現状で60名、登録予定の配信者で100名以上いるため、今以上にページネーションのページ数が増えると予想
機能第一弾としては、カテゴリー検索で配信開始年毎に検索を行えるようにする事で、1度に表示する配信者の絞り込みを行う

## どういう作業を行ったか

カテゴリー検索部分にリストで2018年から2023年までの年号を表示させる。
NextのLinkを使い、ページ遷移をする準備を行う


## Next Point

 - None

## 変更画面のサンプル
### ワイヤーフレーム
![名称未設定](https://github.com/OKAUEND/ffxiv_vtuber_archives/assets/38197580/3fe3ac92-3d80-4f6f-9fbb-6b3b60cc8fd5)

### 変更前
![b52d0f0e449fb729981e28e04195bd74](https://github.com/OKAUEND/ffxiv_vtuber_archives/assets/38197580/1a03f22c-72a9-4380-93c7-541754c061f8)

### 変更後
![b6149bf6124518d5286762ca6b0aa58d](https://github.com/OKAUEND/ffxiv_vtuber_archives/assets/38197580/5dc78f11-29d1-4f25-a9f8-1cf11703268b)


## 参考資料
 - None
