### PR TITLE
反映 - 検索画面より結果画面へ遷移し、QueryParametaを取得できるようにする

### DIFF
--- a/app/channels/_components/Search/SearchCategories.tsx
+++ b/app/channels/_components/Search/SearchCategories.tsx
@@ -18,7 +18,9 @@ export const SearchCategories = () => {
         <ul>
           {beginLiveYears.map((year) => (
             <li key={year.key}>
-              <Link href={'/channels/result'}>{year.name}</Link>
+              <Link href={`/channels/result?year=${year.key}`}>
+                {year.name}
+              </Link>
             </li>
           ))}
         </ul>

--- a/app/channels/result/page.tsx
+++ b/app/channels/result/page.tsx
@@ -1,7 +1,7 @@
 export default async function ChannelResultIndex({
-  params,
+  searchParams,
 }: {
-  params: { query: string };
+  searchParams;
 }) {
   return <></>;
 }

--- a/app/channels/result/page.tsx
+++ b/app/channels/result/page.tsx
@@ -1,7 +1,12 @@
+interface SearchParams {
+  orderBy: string;
+  year: string;
+}
+
 export default async function ChannelResultIndex({
   searchParams,
 }: {
-  searchParams;
+  searchParams: SearchParams;
 }) {
   return <></>;
 }


### PR DESCRIPTION
## Issue / Ticket

### 作業カテゴリー

[Trello - 機能 - 配信者の名前や配信日の降順昇順、配信年でフィルタリングをし、簡易検索機能を実現する](https://trello.com/c/Xch6WvPQ/45-%E6%A9%9F%E8%83%BD-%E9%85%8D%E4%BF%A1%E8%80%85%E3%81%AE%E5%90%8D%E5%89%8D%E3%82%84%E9%85%8D%E4%BF%A1%E6%97%A5%E3%81%AE%E9%99%8D%E9%A0%86%E6%98%87%E9%A0%86%E3%80%81%E9%85%8D%E4%BF%A1%E5%B9%B4%E3%81%A7%E3%83%95%E3%82%A3%E3%83%AB%E3%82%BF%E3%83%AA%E3%83%B3%E3%82%B0%E3%82%92%E3%81%97%E3%80%81%E7%B0%A1%E6%98%93%E6%A4%9C%E7%B4%A2%E6%A9%9F%E8%83%BD%E3%82%92%E5%AE%9F%E7%8F%BE%E3%81%99%E3%82%8B)

### 作業チケット

[Trello - カテゴリー検索の内容を押下すると、警告文無しにchannel/result/[Dynamic]へ遷移をする](https://trello.com/c/lCuxRd74/55-%E3%82%AB%E3%83%86%E3%82%B4%E3%83%AA%E3%83%BC%E6%A4%9C%E7%B4%A2%E3%81%AE%E5%86%85%E5%AE%B9%E3%82%92%E6%8A%BC%E4%B8%8B%E3%81%99%E3%82%8B%E3%81%A8%E3%80%81%E8%AD%A6%E5%91%8A%E6%96%87%E7%84%A1%E3%81%97%E3%81%ABchannel-result-dynamic%E3%81%B8%E9%81%B7%E7%A7%BB%E3%82%92%E3%81%99%E3%82%8B)
[Trello - result画面で、QueryParameterを受け取る](https://trello.com/c/fk9AmB55/56-result%E7%94%BB%E9%9D%A2%E3%81%A7%E3%80%81queryparameter%E3%82%92%E5%8F%97%E3%81%91%E5%8F%96%E3%82%8B)

## 課題/何が起こったか

検索結果毎にページを作る場合では、検索の種類で画面数が膨大に増えるので1画面で全ての検索処理を行いたい


## 仮説/どうしてそうなったのか

検索クエリパラメーターをURLのクエリパラメータで受け取りたいため、Next.jsのAPIを利用し、サーバーサイドでクエリパラメータを受け取る
なぜサーバーサイドかといえば、Next.jsはサーバー側へ処理を寄せるのが推奨されているため、クライアントではなくサーバで行う

## どういう作業を行ったか

検索結果画面の引数で、searchParamsを受け取る

## Next Point

 - None

## 変更画面のサンプル

- None 

## 参考資料
 - [App Router - 規則 - page.js](https://nextjs.org/docs/app/api-reference/file-conventions/page)
