### PR TITLE
反映 - 全体にスタイルを反映するために、pageからLayoutへreset.cssのインポートを移動させる

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import 'sanitize.css';
+import '@/_styles/reset.scss';
 
 import styles from '@/_styles/rootLayout.module.scss';
 import RecoilProvider from '@/_utile/recoil';

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,4 +1,3 @@
-import '@/_styles/reset.scss';
 import styles from '@/_styles/rootPage.module.scss';
 
 import { Pagination } from './_components/Pagination';


### PR DESCRIPTION
## Issue / Ticket

### 作業カテゴリー

[Trello - 機能 - 配信者の名前や配信日の降順昇順、配信年でフィルタリングをし、簡易検索機能を実現する](https://trello.com/c/Xch6WvPQ/45-%E6%A9%9F%E8%83%BD-%E9%85%8D%E4%BF%A1%E8%80%85%E3%81%AE%E5%90%8D%E5%89%8D%E3%82%84%E9%85%8D%E4%BF%A1%E6%97%A5%E3%81%AE%E9%99%8D%E9%A0%86%E6%98%87%E9%A0%86%E3%80%81%E9%85%8D%E4%BF%A1%E5%B9%B4%E3%81%A7%E3%83%95%E3%82%A3%E3%83%AB%E3%82%BF%E3%83%AA%E3%83%B3%E3%82%B0%E3%82%92%E3%81%97%E3%80%81%E7%B0%A1%E6%98%93%E6%A4%9C%E7%B4%A2%E6%A9%9F%E8%83%BD%E3%82%92%E5%AE%9F%E7%8F%BE%E3%81%99%E3%82%8B)

### 作業チケット

- none

## 課題/何が起こったか

検索結果画面で配信者の一覧を表示した時に、リンクで下線などが表示され、トップ画面と同じスタイルになっていなかった

## 仮説/どうしてそうなったのか

リンクのスタイルは、自作のリセットCSSでスタイルの指定をし直している
そのリセットCSSがトップのPageで読み込みが行われていたので、他ページに反映されていなかった

## どういう作業を行ったか

PageからRootLayoutへ移動し、ページ遷移をしてもスタイルが有効になるようにする

## Next Point

 - none

## 変更画面のサンプル

- none

## 参考資料
 - None
