### PR TITLE
変更 - ページネーションで生成するリンクに、URLのクエリパラメータを付けてパスを生成する

### DIFF
--- a/app/_components/Pagination/index.tsx
+++ b/app/_components/Pagination/index.tsx
@@ -4,9 +4,10 @@ import Link from 'next/link';
 
 import styles from './pagination.module.scss';
 
-interface Props {
+interface Props<T> {
   // totalCount: number;
   basePath: string;
+  query?: T;
   currentPageNumber: number;
   totalCount: number;
 }
@@ -38,13 +39,33 @@ const createOffsetNumber = (pageNumber: number, currantNumber: number) => {
   return currantNumber > pageNumber - 1 ? currantNumber - 2 : 1;
 };
 
-export const Pagination = ({
+/**
+ * クエリパラメータがあるページへの遷移が必要な場合、動的に文字列のクエリパラメータを作成する
+ * @param query
+ * @returns
+ */
+export const createQueryParameter = <T,>(query: T): string => {
+  if (!query || query === '') return '';
+
+  if (typeof query === 'object') {
+    const keys = Object.entries(query);
+    return keys.reduce((acc, currentValue, index) => {
+      if (index === 0) return `/?${currentValue[0]}=${currentValue[1]}`;
+
+      return `${acc}&${currentValue[0]}=${currentValue[1]}`;
+    }, '');
+  }
+};
+
+export const Pagination = <T,>({
   basePath,
+  query,
   currentPageNumber = 1,
   totalCount,
-}: Props) => {
+}: Props<T>) => {
   const maxPage = createPageNumber(totalCount);
   const offsetPageNumber = createOffsetNumber(maxPage, currentPageNumber);
+  const queryParameter = createQueryParameter<T>(query);
 
   const paginationList = () =>
     [...Array(maxPage)].map((_, index) => offsetPageNumber + index);
@@ -66,7 +87,10 @@ export const Pagination = ({
           {currentPageNumber === number ? (
             <div>{number}</div>
           ) : (
-            <Link href={`${basePath}/${number}`} className={styles.link}>
+            <Link
+              href={`${basePath}${number}${queryParameter}`}
+              className={styles.link}
+            >
               {number}
             </Link>
           )}

--- a/app/channels/_components/Result/router.tsx
+++ b/app/channels/_components/Result/router.tsx
@@ -20,6 +20,7 @@ export const ChannelResult = async ({ page, params }: IProps) => {
 
         <Pagination<ChannelSearchParams>
           basePath="channels/result/"
+          query={params}
           currentPageNumber={Number(page)}
           totalCount={count}
         />


### PR DESCRIPTION
## Issue / Ticket

### 作業カテゴリー

[Trello - 機能 - 配信者の名前や配信日の降順昇順、配信年でフィルタリングをし、簡易検索機能を実現する](https://trello.com/c/Xch6WvPQ/45-%E6%A9%9F%E8%83%BD-%E9%85%8D%E4%BF%A1%E8%80%85%E3%81%AE%E5%90%8D%E5%89%8D%E3%82%84%E9%85%8D%E4%BF%A1%E6%97%A5%E3%81%AE%E9%99%8D%E9%A0%86%E6%98%87%E9%A0%86%E3%80%81%E9%85%8D%E4%BF%A1%E5%B9%B4%E3%81%A7%E3%83%95%E3%82%A3%E3%83%AB%E3%82%BF%E3%83%AA%E3%83%B3%E3%82%B0%E3%82%92%E3%81%97%E3%80%81%E7%B0%A1%E6%98%93%E6%A4%9C%E7%B4%A2%E6%A9%9F%E8%83%BD%E3%82%92%E5%AE%9F%E7%8F%BE%E3%81%99%E3%82%8B)

### 作業チケット

- none

## 課題/何が起こったか

結果ページが複数のページに渡る場合、2ページ以降は検索内容が引き継がれておらず、検索されない

## 仮説/どうしてそうなったのか

1ページ目はリンクにクエリパラメータが付与されているが、2ページ以降はリンクにクエリパラメータが付与されていない
そのため、1ページ目の検索が2ページ以降に引き継がれておらず、結果が表示されなかった

## どういう作業を行ったか

クエリパラメータを取得し、再度生成しリンクへ付与する

## Next Point

 - none

## 変更画面のサンプル

- none

## 参考資料
 - None
