### PR TITLE
変更 - 総件数が20件未満のときは、ページネーションの表示MAX件数を0件にし、表示させなくする

### DIFF
--- a/app/_components/Pagination/index.tsx
+++ b/app/_components/Pagination/index.tsx
@@ -20,6 +20,7 @@ const MAX_PAGE = 5;
  * @returns
  */
 const createPageNumber = (totalCount: number) => {
+  if (20 > totalCount) return 0;
   const totalPageNumber = Math.ceil(totalCount / 20);
   if (totalPageNumber > MAX_PAGE) return MAX_PAGE;
 


### PR DESCRIPTION
## Issue / Ticket

### 作業カテゴリー

[Trello - 機能 - 配信者の名前や配信日の降順昇順、配信年でフィルタリングをし、簡易検索機能を実現する](https://trello.com/c/Xch6WvPQ/45-%E6%A9%9F%E8%83%BD-%E9%85%8D%E4%BF%A1%E8%80%85%E3%81%AE%E5%90%8D%E5%89%8D%E3%82%84%E9%85%8D%E4%BF%A1%E6%97%A5%E3%81%AE%E9%99%8D%E9%A0%86%E6%98%87%E9%A0%86%E3%80%81%E9%85%8D%E4%BF%A1%E5%B9%B4%E3%81%A7%E3%83%95%E3%82%A3%E3%83%AB%E3%82%BF%E3%83%AA%E3%83%B3%E3%82%B0%E3%82%92%E3%81%97%E3%80%81%E7%B0%A1%E6%98%93%E6%A4%9C%E7%B4%A2%E6%A9%9F%E8%83%BD%E3%82%92%E5%AE%9F%E7%8F%BE%E3%81%99%E3%82%8B)

### 作業チケット

- none

## 課題/何が起こったか

総件数が20件未満でもページネーションのリンクが表示されている
ページ遷移をする必要がないので、表示されなくていい要素

## 仮説/どうしてそうなったのか

20件未満でも、小数点切り上げで1ページはあると判定しているため

## どういう作業を行ったか

20件未満だとMAX件数を0件にし、ページネーションを表示させない

## Next Point

 - none

## 変更画面のサンプル

- none

## 参考資料
 - None
