### PR TITLE
反映 - 検索フォームを検索画面だけではなく、結果画面にも配置し再検索を画面移動無しで行えるようにする

### DIFF
--- a/app/_components/Accordion/(hook)/useAccordion.ts
+++ b/app/_components/Accordion/(hook)/useAccordion.ts
@@ -1,1 +1,24 @@
-export const useAccordion = () => {};
+import { atom, selector, useRecoilValue, useRecoilCallback } from 'recoil';
+
+const accordionHidden = atom<boolean>({
+  key: 'state/accordion-visible',
+  default: true,
+});
+
+const createAccordionStyles = selector<string>({
+  key: 'create/accordion-style',
+  get: ({ get }) => {
+    const isHidden = get(accordionHidden);
+    return isHidden ? '--open' : '--hidden';
+  },
+});
+
+export const useAccordion = () => {
+  const accordionStyle = useRecoilValue(createAccordionStyles);
+
+  const changeHidden = useRecoilCallback(({ set }) => () => {
+    set(accordionHidden, (prev) => !prev);
+  });
+
+  return [accordionStyle, changeHidden] as const;
+};

--- a/app/_components/Accordion/(hook)/useAccordion.ts
+++ b/app/_components/Accordion/(hook)/useAccordion.ts
@@ -1,4 +1,5 @@
 import { atom, selector, useRecoilValue, useRecoilCallback } from 'recoil';
+import styles from '../accordion.module.scss';
 
 const accordionHidden = atom<boolean>({
   key: 'state/accordion-visible',
@@ -9,7 +10,7 @@ const createAccordionStyles = selector<string>({
   key: 'create/accordion-style',
   get: ({ get }) => {
     const isHidden = get(accordionHidden);
-    return isHidden ? '--open' : '--hidden';
+    return isHidden ? `${styles.hidden}` : `${styles.open}`;
   },
 });
 

--- a/app/_components/Accordion/(hook)/useAccordion.ts
+++ b/app/_components/Accordion/(hook)/useAccordion.ts
@@ -1,0 +1,1 @@
+export const useAccordion = () => {};

--- a/app/_components/Accordion/Accordion.tsx
+++ b/app/_components/Accordion/Accordion.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import {} from './(hook)/useAccordion';
+import { useAccordion } from './(hook)/useAccordion';
 import styles from './accordion.module.scss';
 
 interface IProps {
@@ -9,10 +9,11 @@ interface IProps {
 }
 
 export const Accordion = ({ title, children }: IProps) => {
+  const [accordionStyle, changeVisible] = useAccordion();
   return (
     <>
-      <button>{title}</button>
-      <div>{children}</div>
+      <button onClick={changeVisible}>{title}</button>
+      <div className={`${accordionStyle}`}>{children}</div>
     </>
   );
 };

--- a/app/_components/Accordion/Accordion.tsx
+++ b/app/_components/Accordion/Accordion.tsx
@@ -11,9 +11,14 @@ interface IProps {
 export const Accordion = ({ title, children }: IProps) => {
   const [accordionStyle, changeVisible] = useAccordion();
   return (
-    <>
-      <button onClick={changeVisible}>{title}</button>
-      <div className={`${accordionStyle}`}>{children}</div>
-    </>
+    <div className={styles.container}>
+      <button
+        className={`${styles.accordion_event} ${accordionStyle}`}
+        onClick={changeVisible}
+      >
+        {title}
+      </button>
+      <div className={`${styles.body} ${accordionStyle}`}>{children}</div>
+    </div>
   );
 };

--- a/app/_components/Accordion/Accordion.tsx
+++ b/app/_components/Accordion/Accordion.tsx
@@ -1,0 +1,18 @@
+'use client';
+
+import {} from './(hook)/useAccordion';
+import styles from './accordion.module.scss';
+
+interface IProps {
+  title: string;
+  children: React.ReactNode;
+}
+
+export const Accordion = ({ title, children }: IProps) => {
+  return (
+    <>
+      <button>{title}</button>
+      <div>{children}</div>
+    </>
+  );
+};

--- a/app/_components/Accordion/accordion.module.scss
+++ b/app/_components/Accordion/accordion.module.scss
@@ -37,10 +37,15 @@
 }
 
 .body {
+  width: 100%;
 
   &.open {
+    border-bottom: 2px rgb(59, 59, 59) solid;
+    padding-bottom: 15px;
   }
 
   &.hidden {
+    display: none;
+    transition: all 0.2s;
   }
 }

--- a/app/_components/Accordion/accordion.module.scss
+++ b/app/_components/Accordion/accordion.module.scss
@@ -1,3 +1,33 @@
+@use '@/_styles/variables/variables.scss';
+
+.container {
+}
+
+.accordion_event {
+  width: 80%;
+  height: 45px;
+  border-radius: 10px;
+
+  font-weight: bold;
+  font-size: 16px;
+  color: variables.$title_color;
+
+  background-color: rgb(47, 55, 70);
+  border: 3px solid rgb(47, 55, 70);
+  transition: all 0.2s;
+
+  @include variables.mq(lg) {
+    width: 400px;
+  }
+
+  &.open {
+    background-color: rgb(99, 111, 129);
+  }
+
+  &.hidden {
+  }
+}
+
 .body {
 
   &.open {

--- a/app/_components/Accordion/accordion.module.scss
+++ b/app/_components/Accordion/accordion.module.scss
@@ -1,0 +1,8 @@
+.body {
+
+  &.open {
+  }
+
+  &.hidden {
+  }
+}

--- a/app/_components/Accordion/accordion.module.scss
+++ b/app/_components/Accordion/accordion.module.scss
@@ -1,6 +1,14 @@
 @use '@/_styles/variables/variables.scss';
 
 .container {
+  width: 100%;
+  margin-top: 10px;
+  display: grid;
+  place-items: center;
+
+  @include variables.mq(lg) {
+    width: 800px;
+  }
 }
 
 .accordion_event {

--- a/app/_components/Accordion/index.tsx
+++ b/app/_components/Accordion/index.tsx
@@ -1,0 +1,1 @@
+export { Accordion } from './Accordion';

--- a/app/_components/RadioList/radios.module.scss
+++ b/app/_components/RadioList/radios.module.scss
@@ -4,12 +4,13 @@
   list-style: none;
   display: flex;
   align-items: center;
+  flex-wrap: wrap;
   padding: 0;
   margin: 0;
 }
 
 .list {
-  width: 120px;
+  width: 100px;
 
   margin: 5px;
 }
@@ -19,6 +20,7 @@
   width: 100%;
   text-align: center;
   padding: 5px;
+  white-space: nowrap;
 }
 
 .checked {

--- a/app/_styles/reset.scss
+++ b/app/_styles/reset.scss
@@ -7,3 +7,11 @@ ul {
   margin: 0;
   padding: 0;
 }
+
+button {
+  border: none;
+  outline: none;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+}

--- a/app/channels/(hooks)/Search/useChannelSearchCategories.ts
+++ b/app/channels/(hooks)/Search/useChannelSearchCategories.ts
@@ -46,3 +46,43 @@ export const useChannelSearchBeginYear = () => {
 
   return [year, beginLiveYears, changeYear] as const;
 };
+
+type Param = [string, string];
+
+export const useInitChannelSearch = () => {
+  const initOrder = useRecoilCallback(({ set }) => (init: Categories) => {
+    set(sortOption, init);
+  });
+  const initYear = useRecoilCallback(({ set }) => (init: Categories) => {
+    set(beginLiveYear, init);
+  });
+
+  const initCategories = (params: ChannelSearchParams) => {
+    if (!params) return;
+    const keys: Param[] = Object.entries(params);
+
+    const findTarget = (dates: Array<Categories>, param: Param) => {
+      return dates.find((value) => value.key === param[1]);
+    };
+
+    keys.forEach((param) => {
+      switch (param[0]) {
+        case 'orderBy': {
+          const target = findTarget(sortOptions, param);
+          initOrder(target);
+          break;
+        }
+        case 'year': {
+          const target = findTarget(beginLiveYears, param);
+          initYear(target);
+          break;
+        }
+        default: {
+          break;
+        }
+      }
+    });
+  };
+
+  return [initCategories] as const;
+};

--- a/app/channels/(hooks)/Search/useChannelSearchCategories.ts
+++ b/app/channels/(hooks)/Search/useChannelSearchCategories.ts
@@ -1,17 +1,12 @@
+import { ChannelSearchParams } from '@/channels/(types)';
+
 import { atom, useRecoilCallback, useRecoilValue } from 'recoil';
+
+type Categories = { key: string; name: string };
 
 const sortOptions = [
   { key: 'Desc', name: '新しい順' },
   { key: 'Asc', name: '古い順' },
-];
-
-const beginLiveYears = [
-  { key: '2018', name: '2018年' },
-  { key: '2019', name: '2019年' },
-  { key: '2020', name: '2020年' },
-  { key: '2021', name: '2021年' },
-  { key: '2022', name: '2022年' },
-  { key: '2023', name: '2023年' },
 ];
 
 const sortOption = atom({
@@ -28,7 +23,16 @@ export const useChannelSearchOption = () => {
   return [option, sortOptions, changeOption] as const;
 };
 
-const beginLiveYear = atom({
+const beginLiveYears = [
+  { key: '2018', name: '2018年' },
+  { key: '2019', name: '2019年' },
+  { key: '2020', name: '2020年' },
+  { key: '2021', name: '2021年' },
+  { key: '2022', name: '2022年' },
+  { key: '2023', name: '2023年' },
+];
+
+const beginLiveYear = atom<Categories>({
   key: 'state/year',
   default: beginLiveYears[0],
 });
@@ -36,8 +40,9 @@ const beginLiveYear = atom({
 export const useChannelSearchBeginYear = () => {
   const year = useRecoilValue(beginLiveYear);
 
-  const changeYear = useRecoilCallback(({ set }) => (year) => {
+  const changeYear = useRecoilCallback(({ set }) => (year: Categories) => {
     set(beginLiveYear, year);
   });
+
   return [year, beginLiveYears, changeYear] as const;
 };

--- a/app/channels/(hooks)/Search/useChannelSearchCategories.ts
+++ b/app/channels/(hooks)/Search/useChannelSearchCategories.ts
@@ -10,6 +10,8 @@ const beginLiveYears = [
   { key: '2019', name: '2019年' },
   { key: '2020', name: '2020年' },
   { key: '2021', name: '2021年' },
+  { key: '2022', name: '2022年' },
+  { key: '2023', name: '2023年' },
 ];
 
 const sortOption = atom({
@@ -27,15 +29,15 @@ export const useChannelSearchOption = () => {
 };
 
 const beginLiveYear = atom({
-  key: 'state/sort-year',
+  key: 'state/year',
   default: beginLiveYears[0],
 });
 
 export const useChannelSearchBeginYear = () => {
-  const yaer = useRecoilValue(beginLiveYear);
+  const year = useRecoilValue(beginLiveYear);
 
   const changeYear = useRecoilCallback(({ set }) => (year) => {
     set(beginLiveYear, year);
   });
-  return [yaer, beginLiveYears, changeYear] as const;
+  return [year, beginLiveYears, changeYear] as const;
 };

--- a/app/channels/(types)/index.ts
+++ b/app/channels/(types)/index.ts
@@ -1,5 +1,4 @@
 export interface ChannelSearchParams {
-  page: string;
   orderBy: string;
   year: string;
 }

--- a/app/channels/_components/Result/router.tsx
+++ b/app/channels/_components/Result/router.tsx
@@ -3,6 +3,9 @@ import { ChannelPanel } from '@/channels/_components/ChannelPanel';
 import { ChannelSearchParams } from '@/channels/(types)';
 import { Pagination } from '@/_components/Pagination';
 import { ErrorBoundaryExtended } from '@/_components/ErrorBoundary';
+import { Accordion } from '@/_components/Accordion';
+
+import { SearchCategories } from '@/channels/_components/Search/SearchCategories';
 
 import styles from '@/_styles/rootPage.module.scss';
 
@@ -13,8 +16,12 @@ interface IProps {
 
 export const ChannelResult = async ({ page, params }: IProps) => {
   const [channels, count] = await getChannelWhere(params, page);
+
   return (
     <section className={styles.content}>
+      <Accordion title="さらにVtuberを探す">
+        <SearchCategories params={params} />
+      </Accordion>
       <ErrorBoundaryExtended>
         <ChannelPanel channels={channels} />
 

--- a/app/channels/_components/Search/SearchCategories.tsx
+++ b/app/channels/_components/Search/SearchCategories.tsx
@@ -1,17 +1,30 @@
 'use client';
+import { useEffect } from 'react';
 
 import { RadioList } from '@/_components/RadioList';
 
 import {
   useChannelSearchOption,
   useChannelSearchBeginYear,
+  useInitChannelSearch,
 } from '@/channels/(hooks)/Search/useChannelSearchCategories';
+import { ChannelSearchParams } from '@/channels/(types)';
 
 import styles from '@/channels/_style/search/search.module.scss';
 
-export const SearchCategories = () => {
+interface IProps {
+  params?: ChannelSearchParams;
+}
+
+export const SearchCategories = ({ params }: IProps) => {
+  const [initCategories] = useInitChannelSearch();
   const [selectedOption, sortData, changeOption] = useChannelSearchOption();
   const [selectedYear, years, changeYear] = useChannelSearchBeginYear();
+
+  useEffect(() => {
+    initCategories(params);
+  }, []);
+
   return (
     <form action="/api/form" method="GET" className={styles.container}>
       <article>

--- a/app/channels/_components/Search/SearchCategories.tsx
+++ b/app/channels/_components/Search/SearchCategories.tsx
@@ -47,7 +47,9 @@ export const SearchCategories = ({ params }: IProps) => {
           changeHandler={changeYear}
         />
       </article>
-      <button>検索する</button>
+      <div>
+        <button className={styles.search_event}>検索する</button>
+      </div>
     </form>
   );
 };

--- a/app/channels/_style/search/search.module.scss
+++ b/app/channels/_style/search/search.module.scss
@@ -1,3 +1,21 @@
+@use '@/_styles/variables/variables.scss';
+
 .container {
   width: 100%;
+}
+
+.search_event {
+  display: grid;
+  place-items: center;
+
+  & .search {
+    width: 200px;
+    height: 45px;
+    border-radius: 10px;
+    background-color: rgb(47, 55, 70);
+
+    font-weight: bold;
+    font-size: 16px;
+    color: variables.$title_color;
+  }
 }


### PR DESCRIPTION
## Issue / Ticket

### 作業カテゴリー

[Trello - 機能 - 配信者の名前や配信日の降順昇順、配信年でフィルタリングをし、簡易検索機能を実現する](https://trello.com/c/Xch6WvPQ/45-%E6%A9%9F%E8%83%BD-%E9%85%8D%E4%BF%A1%E8%80%85%E3%81%AE%E5%90%8D%E5%89%8D%E3%82%84%E9%85%8D%E4%BF%A1%E6%97%A5%E3%81%AE%E9%99%8D%E9%A0%86%E6%98%87%E9%A0%86%E3%80%81%E9%85%8D%E4%BF%A1%E5%B9%B4%E3%81%A7%E3%83%95%E3%82%A3%E3%83%AB%E3%82%BF%E3%83%AA%E3%83%B3%E3%82%B0%E3%82%92%E3%81%97%E3%80%81%E7%B0%A1%E6%98%93%E6%A4%9C%E7%B4%A2%E6%A9%9F%E8%83%BD%E3%82%92%E5%AE%9F%E7%8F%BE%E3%81%99%E3%82%8B)

#69
### 作業チケット
[結果画面に、検索画面の検索フォームを配置](https://trello.com/c/FAiomlRY/69-%E7%B5%90%E6%9E%9C%E7%94%BB%E9%9D%A2%E3%81%AB%E3%80%81%E6%A4%9C%E7%B4%A2%E7%94%BB%E9%9D%A2%E3%81%AE%E6%A4%9C%E7%B4%A2%E3%83%95%E3%82%A9%E3%83%BC%E3%83%A0%E3%82%92%E9%85%8D%E7%BD%AE)
[結果画面の検索フォームをアコーディオンで表示非表示を可能にし、表示を小さくさせる](結果画面の検索フォームをアコーディオンで表示非表示を可能にし、表示を小さくさせる)

## 課題/何が起こったか

結果画面から再検索を行う場合には、一度ブラウザの戻るかTOPページに戻って検索画面に入りなおすしかルートがないので、アクションが多くめんどくさい

## 仮説/どうしてそうなったのか

検索し直すには、一度ユーザーが戻るアクションをすればよいと想定していた
レビューでの指摘で、なるべくユーザーへ戻る操作を促すような設計はNGとあったので、
結果画面にフォームを設置し、同じ画面から再度検索できるようにする
また、前回の検索内容をフォームに反映し、前に何を検索したかの状態を維持することで、ユーザーが前回の操作を忘れないようにする
結果画面でフォームの操作がない場合、初期値のままだと内容をRouteHandler経由で次の結果画面へ送信できないため、
あえて前回の内容を初期化処理として行う事で、即座に検索ボタンを押しても

## どういう作業を行ったか

検索フォーム一式のSearchCategoriesを結果画面の上部に配置
表示する領域が広いため、結果のみを表示できるようにアコーディオンを新規実装し、検索フォームを閉じれるようにする
クエリパラメータをループで処理し、同じ配列データの内容を状態へセットすることで、前回の検索内容を状態へ反映する

## Next Point

 - 検索画面でも、前回の検索内容が引き継がれている
 - 結果画面で前回の検索内容が引き継がれている
 - ボタンのデザイン

## 変更画面のサンプル
### 変更前
![bb8cbbba442e47a37375e53a3e015015](https://github.com/OKAUEND/ffxiv_vtuber_archives/assets/38197580/40d6b162-e214-48fc-934a-463ebd8513ba)

### 変更後
![c6cb3155d769b6a6ba31107a8dcae459](https://github.com/OKAUEND/ffxiv_vtuber_archives/assets/38197580/8f26e307-3fea-462f-8e3e-91ac7007bc35)

### 遷移時の動作
![979a26fb612568d05e39799291cc7037](https://github.com/OKAUEND/ffxiv_vtuber_archives/assets/38197580/4bf9c0b0-a4a7-488d-bd24-af465f63212e)


## 参考資料
 - none

