### PR TITLE
反映 - アコーディオンの機能に対してテストを実装。他ラジオボタンのテストで失敗部分を修正

### DIFF
--- a/app/_components/Accordion/__tests__/Accordion.test.tsx
+++ b/app/_components/Accordion/__tests__/Accordion.test.tsx
@@ -1,5 +1,34 @@
 import { describe, test, vi } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import { RecoilRoot } from 'recoil';
 
-describe('Accordion Component TEST', () => {});
+import { Accordion } from '../Accordion';
+
+describe('Accordion Component TEST', () => {
+  const TestComponent = () => <div>Component TEST</div>;
+  test('ボタンにPropsのTitleの要素が表示されているか', async () => {
+    render(
+      <RecoilRoot>
+        <Accordion title="Accordion Button">
+          <TestComponent />
+        </Accordion>
+      </RecoilRoot>
+    );
+
+    const ButtonTEXT = await screen.getByText('Accordion Button');
+    expect(ButtonTEXT.textContent).toEqual('Accordion Button');
+  });
+  test('子のComponentは表示できているか', async () => {
+    render(
+      <RecoilRoot>
+        <Accordion title="Accordion Button">
+          <TestComponent />
+        </Accordion>
+      </RecoilRoot>
+    );
+
+    const ChildTEXT = await screen.getByText('Component TEST');
+    expect(ChildTEXT.textContent).toEqual('Component TEST');
+  });
+});

--- a/app/_components/Accordion/__tests__/Accordion.test.tsx
+++ b/app/_components/Accordion/__tests__/Accordion.test.tsx
@@ -1,0 +1,5 @@
+import { describe, test, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+describe('Accordion Component TEST', () => {});

--- a/app/_components/Accordion/__tests__/AccordionHook.test.ts
+++ b/app/_components/Accordion/__tests__/AccordionHook.test.ts
@@ -1,0 +1,5 @@
+import { describe, test, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+describe('Accordion Hook TEST', () => {});

--- a/app/_components/Accordion/__tests__/AccordionHook.test.ts
+++ b/app/_components/Accordion/__tests__/AccordionHook.test.ts
@@ -1,5 +1,31 @@
 import { describe, test, vi } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { render, screen, renderHook, act } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
-describe('Accordion Hook TEST', () => {});
+import { useAccordion } from '../(hook)/useAccordion';
+import { RecoilRoot } from 'recoil';
+
+describe('Accordion Hook TEST', () => {
+  test('Hookの初期状態で、値が文字列のクローズ状態なのを示している', () => {
+    const { result } = renderHook(() => useAccordion(), {
+      wrapper: RecoilRoot,
+    });
+
+    expect(result.current[0]).toMatch(/hidden/);
+  });
+
+  test('Changeイベントを呼び出したら、値の文字列がオープンの状態を示しているか', () => {
+    const { result } = renderHook(() => useAccordion(), {
+      wrapper: RecoilRoot,
+    });
+
+    expect(result.current[0]).toMatch(/hidden/);
+
+    act(() => {
+      result.current[1]();
+    });
+
+    expect(result.current[0]).not.toMatch(/hidden/);
+    expect(result.current[0]).toMatch(/open/);
+  });
+});

--- a/app/_components/RadioList/__tests__/RadioList.test.tsx
+++ b/app/_components/RadioList/__tests__/RadioList.test.tsx
@@ -4,7 +4,11 @@ import userEvent from '@testing-library/user-event';
 import { RadioList } from '../RadioList';
 
 describe('RadioList', () => {
-  const categories = ['Category 1', 'Category 2', 'Category 3'];
+  const categories = [
+    { key: 'Category1', name: 'Category 1' },
+    { key: 'Category2', name: 'Category 2' },
+    { key: 'Category3', name: 'Category 3' },
+  ];
   const selected = 'Category 1';
   const group = 'category';
   const changeHandler = vi.fn();
@@ -23,7 +27,8 @@ describe('RadioList', () => {
     expect(radioButtons.length).toBe(categories.length);
 
     const labels = radioButtons.map((item) => item.textContent);
-    expect(labels).toEqual(categories);
+    const CategoryNames = categories.map((item) => item.name);
+    expect(labels).toEqual(CategoryNames);
   });
 
   test('ラジオボタンがクリックされた時、引数として渡された変更関数が呼び出されているか', async () => {
@@ -40,7 +45,7 @@ describe('RadioList', () => {
 
     const targetValue = categories[1]; // Select the second category
 
-    const targetRadio = screen.getByLabelText(targetValue);
+    const targetRadio = screen.getByLabelText(targetValue.name);
 
     expect(changeHandler).toHaveBeenCalledTimes(0);
 


### PR DESCRIPTION
## Issue / Ticket

### 作業カテゴリー

[Trello - 機能 - 配信者の名前や配信日の降順昇順、配信年でフィルタリングをし、簡易検索機能を実現する](https://trello.com/c/Xch6WvPQ/45-%E6%A9%9F%E8%83%BD-%E9%85%8D%E4%BF%A1%E8%80%85%E3%81%AE%E5%90%8D%E5%89%8D%E3%82%84%E9%85%8D%E4%BF%A1%E6%97%A5%E3%81%AE%E9%99%8D%E9%A0%86%E6%98%87%E9%A0%86%E3%80%81%E9%85%8D%E4%BF%A1%E5%B9%B4%E3%81%A7%E3%83%95%E3%82%A3%E3%83%AB%E3%82%BF%E3%83%AA%E3%83%B3%E3%82%B0%E3%82%92%E3%81%97%E3%80%81%E7%B0%A1%E6%98%93%E6%A4%9C%E7%B4%A2%E6%A9%9F%E8%83%BD%E3%82%92%E5%AE%9F%E7%8F%BE%E3%81%99%E3%82%8B)

#69
### 作業チケット
[結果画面に、検索画面の検索フォームを配置](https://trello.com/c/FAiomlRY/69-%E7%B5%90%E6%9E%9C%E7%94%BB%E9%9D%A2%E3%81%AB%E3%80%81%E6%A4%9C%E7%B4%A2%E7%94%BB%E9%9D%A2%E3%81%AE%E6%A4%9C%E7%B4%A2%E3%83%95%E3%82%A9%E3%83%BC%E3%83%A0%E3%82%92%E9%85%8D%E7%BD%AE)
[結果画面の検索フォームをアコーディオンで表示非表示を可能にし、表示を小さくさせる](結果画面の検索フォームをアコーディオンで表示非表示を可能にし、表示を小さくさせる)

## 課題/何が起こったか

アコーディオンの機能に対して機能保証がされていない

## 仮説/どうしてそうなったのか

HooksとComponentに対してTESTがなく、開発者モードでの操作でしか機能の確認ができていなかったから

## どういう作業を行ったか

HookとComponentに対してユニットテストを実装

## Next Point

 - ComponentTESTに対しては、もう少し種類を増やすべきか？

## 変更画面のサンプル

- none

## 参考資料
 - none

