### PR TITLE
変更 - トップ画面から、検索画面へのリンクがないので、検索画面へ遷移するリンクを設置する

### DIFF
--- a/app/_styles/rootPage.module.scss
+++ b/app/_styles/rootPage.module.scss
@@ -1,7 +1,39 @@
+@use './variables/variables.scss';
+
+$forcus_color: #687792;
+
 .content {
   display: flex;
   min-height: 100%;
   flex-direction: column;
   align-items: center;
-  justify-content: space-between;
+  // justify-content: space-between;
+}
+
+.search_container {
+  width: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: right;
+
+  margin-top: 10px;
+
+  & .link {
+    width: 170px;
+    height: 40px;
+    display: grid;
+    place-items: center;
+    color: variables.$text_color;
+    font-size: large;
+    font-weight: 600;
+    transition: all 0.2s;
+
+    &:focus {
+      background-color: $forcus_color;
+    }
+
+    &:hover {
+      background-color: $forcus_color;
+    }
+  }
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -5,6 +5,7 @@ import { ChannelPanel } from '@/channels/_components/ChannelPanel';
 import { ErrorBoundaryExtended } from '@/_components/ErrorBoundary';
 import { HikasenVtuber } from './(types)';
 import { getChannelOffset, getChannelCount } from './_utile/prisma';
+import Link from 'next/link';
 
 const getChannel = async (): Promise<readonly [HikasenVtuber[], number]> => {
   const channels = await getChannelOffset(0);
@@ -17,6 +18,11 @@ export default async function Home() {
   const [channels, totalCount] = await getChannel();
   return (
     <section className={styles.content}>
+      <div className={styles.search_container}>
+        <Link className={styles.link} href={'/channels/search'}>
+          配信者を探す→
+        </Link>
+      </div>
       <ErrorBoundaryExtended>
         <ChannelPanel channels={channels} />
 


### PR DESCRIPTION
## Issue / Ticket

### 作業カテゴリー

[Trello - 機能 - 配信者の名前や配信日の降順昇順、配信年でフィルタリングをし、簡易検索機能を実現する](https://trello.com/c/Xch6WvPQ/45-%E6%A9%9F%E8%83%BD-%E9%85%8D%E4%BF%A1%E8%80%85%E3%81%AE%E5%90%8D%E5%89%8D%E3%82%84%E9%85%8D%E4%BF%A1%E6%97%A5%E3%81%AE%E9%99%8D%E9%A0%86%E6%98%87%E9%A0%86%E3%80%81%E9%85%8D%E4%BF%A1%E5%B9%B4%E3%81%A7%E3%83%95%E3%82%A3%E3%83%AB%E3%82%BF%E3%83%AA%E3%83%B3%E3%82%B0%E3%82%92%E3%81%97%E3%80%81%E7%B0%A1%E6%98%93%E6%A4%9C%E7%B4%A2%E6%A9%9F%E8%83%BD%E3%82%92%E5%AE%9F%E7%8F%BE%E3%81%99%E3%82%8B)

#69
### 作業チケット
[TOPページの右上に検索ページへ遷移をするリンクを配置する。リンクの文言は「探す　→」とする](https://trello.com/c/3jHuvfzv/64-top%E3%83%9A%E3%83%BC%E3%82%B8%E3%81%AE%E5%8F%B3%E4%B8%8A%E3%81%AB%E6%A4%9C%E7%B4%A2%E3%83%9A%E3%83%BC%E3%82%B8%E3%81%B8%E9%81%B7%E7%A7%BB%E3%82%92%E3%81%99%E3%82%8B%E3%83%AA%E3%83%B3%E3%82%AF%E3%82%92%E9%85%8D%E7%BD%AE%E3%81%99%E3%82%8B%E3%80%82%E3%83%AA%E3%83%B3%E3%82%AF%E3%81%AE%E6%96%87%E8%A8%80%E3%81%AF%E3%80%8C%E6%8E%A2%E3%81%99-%E2%86%92%E3%80%8D%E3%81%A8%E3%81%99%E3%82%8B)

## 課題/何が起こったか

TOPページから検索画面へ行く手段がない

## 仮説/どうしてそうなったのか

TOPページから検索画面へ行く手段を設置していなかった

## どういう作業を行ったか

TOPページの右上に検索画面へ遷移するnext/linkのLinkを設置する

## Next Point

 - カーソルを合わせたときのスタイルをもう少しやわらかくすべきかもしれない

## 変更画面のサンプル
### 変更前
![167c577c56a0d797ef6ac443484c3f35](https://github.com/OKAUEND/ffxiv_vtuber_archives/assets/38197580/82f15b12-b6ef-49f2-aba6-970a93b13076)

### 変更後
![802ba9638c4a37666eec382c645393b3](https://github.com/OKAUEND/ffxiv_vtuber_archives/assets/38197580/66d4178b-40fa-4c4f-b926-82fe76c241e5)

### 遷移時の動作
![fb75c9628040b40487fe86ee718bae99](https://github.com/OKAUEND/ffxiv_vtuber_archives/assets/38197580/c184f018-8248-4b5c-a1ef-ea2477bcc613)


## 参考資料
 - none

