### PR TITLE
反映 - アコーディオンの表示非表示を、CSSで実現するのではなく、真偽値を使いロジックで表示非表示へ変更

### DIFF
--- a/app/_components/Accordion/(hook)/useAccordion.ts
+++ b/app/_components/Accordion/(hook)/useAccordion.ts
@@ -15,11 +15,12 @@ const createAccordionStyles = selector<string>({
 });
 
 export const useAccordion = () => {
-  const accordionStyle = useRecoilValue(createAccordionStyles);
+  const isHidden = useRecoilValue(accordionHidden);
+  const styles = useRecoilValue(createAccordionStyles);
 
   const changeHidden = useRecoilCallback(({ set }) => () => {
     set(accordionHidden, (prev) => !prev);
   });
 
-  return [accordionStyle, changeHidden] as const;
+  return [isHidden, styles, changeHidden] as const;
 };

--- a/app/_components/Accordion/Accordion.tsx
+++ b/app/_components/Accordion/Accordion.tsx
@@ -9,7 +9,7 @@ interface IProps {
 }
 
 export const Accordion = ({ title, children }: IProps) => {
-  const [accordionStyle, changeVisible] = useAccordion();
+  const [isHidden, accordionStyle, changeVisible] = useAccordion();
   return (
     <div className={styles.container}>
       <button
@@ -18,7 +18,7 @@ export const Accordion = ({ title, children }: IProps) => {
       >
         {title}
       </button>
-      <div className={`${styles.body} ${accordionStyle}`}>{children}</div>
+      <div className={`${styles.body}`}>{isHidden ? <></> : children}</div>
     </div>
   );
 };

--- a/app/_components/Accordion/__tests__/Accordion.test.tsx
+++ b/app/_components/Accordion/__tests__/Accordion.test.tsx
@@ -18,8 +18,9 @@ describe('Accordion Component TEST', () => {
 
     const ButtonTEXT = await screen.getByText('Accordion Button');
     expect(ButtonTEXT.textContent).toEqual('Accordion Button');
+    expect(screen.queryByText('Component TEST')).toBeNull();
   });
-  test('子のComponentは表示できているか', async () => {
+  test('開閉ボタンを押下した時、子の要素は表示されるか', async () => {
     render(
       <RecoilRoot>
         <Accordion title="Accordion Button">
@@ -28,7 +29,39 @@ describe('Accordion Component TEST', () => {
       </RecoilRoot>
     );
 
-    const ChildTEXT = await screen.getByText('Component TEST');
+    const user = userEvent.setup();
+
+    expect(screen.queryByText('Component TEST')).toBeNull();
+
+    const AccButton = await screen.getByText('Accordion Button');
+
+    await user.click(AccButton);
+
+    const ChildTEXT = screen.getByText('Component TEST');
     expect(ChildTEXT.textContent).toEqual('Component TEST');
+  });
+  test('開閉ボタンを2回押下した時、子の要素は表示されない状態になっているか', async () => {
+    render(
+      <RecoilRoot>
+        <Accordion title="Accordion Button">
+          <TestComponent />
+        </Accordion>
+      </RecoilRoot>
+    );
+
+    const user = userEvent.setup();
+
+    expect(screen.queryByText('Component TEST')).toBeNull();
+
+    const AccButton = await screen.getByText('Accordion Button');
+
+    await user.click(AccButton);
+
+    const ChildTEXT = screen.getByText('Component TEST');
+    expect(ChildTEXT.textContent).toEqual('Component TEST');
+
+    await user.click(AccButton);
+
+    expect(screen.queryByText('Component TEST')).toBeNull();
   });
 });

--- a/app/_components/Accordion/__tests__/AccordionHook.test.ts
+++ b/app/_components/Accordion/__tests__/AccordionHook.test.ts
@@ -11,21 +11,27 @@ describe('Accordion Hook TEST', () => {
       wrapper: RecoilRoot,
     });
 
-    expect(result.current[0]).toMatch(/hidden/);
+    expect(result.current[0]).toEqual(true);
+    expect(result.current[1]).toMatch(/hidden/);
   });
 
   test('Changeイベントを呼び出したら、値の文字列がオープンの状態を示しているか', () => {
-    const { result } = renderHook(() => useAccordion(), {
+    const { result, rerender } = renderHook(() => useAccordion(), {
       wrapper: RecoilRoot,
     });
 
-    expect(result.current[0]).toMatch(/hidden/);
+    rerender();
+
+    expect(result.current[0]).toEqual(true);
+    expect(result.current[1]).toMatch(/hidden/);
 
     act(() => {
-      result.current[1]();
+      result.current[2]();
     });
 
-    expect(result.current[0]).not.toMatch(/hidden/);
-    expect(result.current[0]).toMatch(/open/);
+    expect(result.current[0]).not.toEqual(true);
+    expect(result.current[1]).not.toMatch(/hidden/);
+    expect(result.current[0]).toEqual(false);
+    expect(result.current[1]).toMatch(/open/);
   });
 });


### PR DESCRIPTION
## Issue / Ticket

### 作業カテゴリー

[Trello - 機能 - 配信者の名前や配信日の降順昇順、配信年でフィルタリングをし、簡易検索機能を実現する](https://trello.com/c/Xch6WvPQ/45-%E6%A9%9F%E8%83%BD-%E9%85%8D%E4%BF%A1%E8%80%85%E3%81%AE%E5%90%8D%E5%89%8D%E3%82%84%E9%85%8D%E4%BF%A1%E6%97%A5%E3%81%AE%E9%99%8D%E9%A0%86%E6%98%87%E9%A0%86%E3%80%81%E9%85%8D%E4%BF%A1%E5%B9%B4%E3%81%A7%E3%83%95%E3%82%A3%E3%83%AB%E3%82%BF%E3%83%AA%E3%83%B3%E3%82%B0%E3%82%92%E3%81%97%E3%80%81%E7%B0%A1%E6%98%93%E6%A4%9C%E7%B4%A2%E6%A9%9F%E8%83%BD%E3%82%92%E5%AE%9F%E7%8F%BE%E3%81%99%E3%82%8B)

#69
### 作業チケット

- none

## 課題/何が起こったか

アコーディオンの実装をCSSで古風なやり方でやっており、テストの要件が書きにくい

## 仮説/どうしてそうなったのか

CSSのスタイルの切り替えで表示非表示を行っていたため、要素としては常に存在はしていた。
そのため、コンポーネントテストで表示非表示のテストを行う時に、対象は存在していたので、テストがしづらかった。
CSSの有無を確認するのは、コンポーネントを真偽値を使い表示の切り替えをするより面倒なので、Reactのロジックを使う風に変更をする

## どういう作業を行ったか

元より表示非表示を真偽値で管理していたため、それをHook外に出し、コンポーネント側で真偽値を元に要素の切り替えを行う。
スタイルを出力するのは、ボタンの見た目を切り替えるために使用するため、ロジック自体を変更はしない

## Next Point

 - none

## 変更画面のサンプル
- none


## 参考資料
 - none

