### PR TITLE
反映 - Vercelへの仮デプロイ時に判明した、検索処理で時間値が存在しないエラーが発生、原因であるクエリ作成処理を変更する

### DIFF
--- a/app/channels/_lib/api/getChannelWhere.ts
+++ b/app/channels/_lib/api/getChannelWhere.ts
@@ -22,33 +22,40 @@ export const getChannelWhere = async (
   return [res, count] as const;
 };
 
-const createWhereQuery = (
-  params: ChannelSearchParams
-): Prisma.ChannelWhereInput => {
-  const keys = Object.entries(params);
+const createWhereQuery = (params: ChannelSearchParams) => {
+  const keys: [string, string][] = Object.entries(params);
 
-  const query = keys.reduce((acc, currentKey) => {
-    //ページ数をParameterで
-    if (currentKey[0] === 'orderBy') return acc;
+  //クエリパラメータをループで処理し、queryオブジェクトにマージしていくことで、1つの検索条件オブジェクトとする
+  let query: Prisma.ChannelWhereInput = {};
+  keys.forEach((value) => {
+    switch (value[0]) {
+      case 'sort':
+        break;
+      case 'year': {
+        const time = new Date(value[1]);
 
-    //まずは配信時間のWhere文だけを作成する
-    //後にタグ検索とかを行いたいので、改修はしようね
-    const beginDayTime = new Date(currentKey[1]);
-    const endDayTime = new Date(currentKey[1]);
-    endDayTime.setMonth(12);
-    endDayTime.setSeconds(-1);
+        //まずは配信時間のWhere文だけを作成する
+        //後にタグ検索とかを行いたいので、改修はしようね
+        const beginDayTime = new Date(time);
+        const endDayTime = new Date(time);
+        endDayTime.setMonth(12);
+        endDayTime.setSeconds(-1);
 
-    const where: Prisma.ChannelWhereInput = {
-      beginTime: {
-        //開始日時
-        gte: beginDayTime,
-        //終了日時
-        lt: endDayTime,
-      },
-    };
-
-    return where;
-  }, {});
+        const where: Prisma.ChannelWhereInput = {
+          beginTime: {
+            //開始日時
+            gte: beginDayTime.toISOString(),
+            //終了日時
+            lt: endDayTime.toISOString(),
+          },
+        };
+        query = { ...query, ...where };
+        break;
+      }
+      default:
+        break;
+    }
+  });
 
   return query;
 };


### PR DESCRIPTION
## Issue / Ticket

### 作業カテゴリー

[Trello - 機能 - 配信者の名前や配信日の降順昇順、配信年でフィルタリングをし、簡易検索機能を実現する](https://trello.com/c/Xch6WvPQ/45-%E6%A9%9F%E8%83%BD-%E9%85%8D%E4%BF%A1%E8%80%85%E3%81%AE%E5%90%8D%E5%89%8D%E3%82%84%E9%85%8D%E4%BF%A1%E6%97%A5%E3%81%AE%E9%99%8D%E9%A0%86%E6%98%87%E9%A0%86%E3%80%81%E9%85%8D%E4%BF%A1%E5%B9%B4%E3%81%A7%E3%83%95%E3%82%A3%E3%83%AB%E3%82%BF%E3%83%AA%E3%83%B3%E3%82%B0%E3%82%92%E3%81%97%E3%80%81%E7%B0%A1%E6%98%93%E6%A4%9C%E7%B4%A2%E6%A9%9F%E8%83%BD%E3%82%92%E5%AE%9F%E7%8F%BE%E3%81%99%E3%82%8B)

#69
### 作業チケット

- none

## 課題/何が起こったか

仮デプロイを行った時に、検索結果画面でPrismaでエラーが発生し、検索結果を得れなかった

## 仮説/どうしてそうなったのか

Where文を作成する時、クエリパラメータのオブジェクトを配列に変換し、ReduceでループさせることでWhere文を作成していた
その時のReduceループでWhere文が作成されずにPrismaの応答処理が走っていたので、エラーとなっていた

## どういう作業を行ったか

Reduceは認知負荷が上がるため、forEachのループ文へ変更
処理の切り分けをSwicthで判別し、変数のオブジェクトへマージしていく処理へ変更をした

## Next Point

 - none

## エラー時の画面
![89ead23e907dfd67c0fc46542ab50593](https://github.com/OKAUEND/ffxiv_vtuber_archives/assets/38197580/e6bd9b96-9919-4198-93b4-0b8e3c7b08b4)


## 参考資料
 - none

