### PR TITLE
反映- 最後尾ページだった場合、次のページのボタンが表示されないように、ガード文を追加する

### DIFF
--- a/app/_components/Pagination/index.tsx
+++ b/app/_components/Pagination/index.tsx
@@ -36,6 +36,7 @@ const createPageNumber = (totalCount: number) => {
 const createOffsetNumber = (pageNumber: number, currantNumber: number) => {
   //2以下は2つ分の以前のページ番号を表示する必要がないため、そのまま値を返す
   if (pageNumber <= 2) return currantNumber;
+  if (pageNumber === currantNumber) return currantNumber - 3;
 
   return currantNumber > pageNumber - 1 ? currantNumber - 2 : 1;
 };
@@ -68,8 +69,9 @@ export const Pagination = <T,>({
   const offsetPageNumber = createOffsetNumber(maxPage, currentPageNumber);
   const queryParameter = createQueryParameter<T>(query);
 
-  const paginationList = () =>
-    [...Array(maxPage)].map((_, index) => offsetPageNumber + index);
+  const paginationList = [...Array(maxPage)].map(
+    (_, index) => offsetPageNumber + index
+  );
 
   const toggleCurrantNumberStyle = (
     currantNumber: number,
@@ -80,7 +82,7 @@ export const Pagination = <T,>({
 
   return (
     <ul className={styles.container}>
-      {paginationList().map((number, index) => (
+      {paginationList.map((number, index) => (
         <li
           className={toggleCurrantNumberStyle(currentPageNumber, number)}
           key={index}


### PR DESCRIPTION
## Issue / Ticket

### 作業カテゴリー

[Trello - 機能 - 配信者の名前や配信日の降順昇順、配信年でフィルタリングをし、簡易検索機能を実現する](https://trello.com/c/Xch6WvPQ/45-%E6%A9%9F%E8%83%BD-%E9%85%8D%E4%BF%A1%E8%80%85%E3%81%AE%E5%90%8D%E5%89%8D%E3%82%84%E9%85%8D%E4%BF%A1%E6%97%A5%E3%81%AE%E9%99%8D%E9%A0%86%E6%98%87%E9%A0%86%E3%80%81%E9%85%8D%E4%BF%A1%E5%B9%B4%E3%81%A7%E3%83%95%E3%82%A3%E3%83%AB%E3%82%BF%E3%83%AA%E3%83%B3%E3%82%B0%E3%82%92%E3%81%97%E3%80%81%E7%B0%A1%E6%98%93%E6%A4%9C%E7%B4%A2%E6%A9%9F%E8%83%BD%E3%82%92%E5%AE%9F%E7%8F%BE%E3%81%99%E3%82%8B)

#69
### 作業チケット

- none

## 課題/何が起こったか

最後尾ページなのに、ページネーションで次のリンクが表示されている

## 仮説/どうしてそうなったのか

現在ページから-2することで、以前のページ分のリンクも生成を行っていた。
最後尾ページでも現在ページから-2をすることで生成していたので、-2のインデックスから5つの値を生成するため、次のページ分が生成されていた。

## どういう作業を行ったか

現在ページが最後尾ページと同等だった場合、-3をする

## Next Point

- none

## 変更画面のサンプル
### 変更前
![db2f2e8d65941d5bfd4d2aa5428626a1](https://github.com/OKAUEND/ffxiv_vtuber_archives/assets/38197580/696c5cc2-7508-4989-ba79-63e899a978d3)

### 変更後
![1febaa1b32dc11245825ec1a2d0119d7](https://github.com/OKAUEND/ffxiv_vtuber_archives/assets/38197580/2c704e44-ba61-4b13-9a74-12b71d0ffa09)

## 参考資料
 - none


