### PR TITLE
反映 - 全配信者表示の場合、2ページ以降にも検索画面へのリンクを設置する

### DIFF
--- a/app/channels/[pages]/page.tsx
+++ b/app/channels/[pages]/page.tsx
@@ -2,6 +2,7 @@ import styles from '@/_styles/rootPage.module.scss';
 
 import { getChannel } from '@/channels/_lib/api/getChannel';
 import { ChannelIndex } from '@/channels/_components/ChannelIndex';
+import Link from 'next/link';
 
 export default async function Article({
   params,
@@ -11,6 +12,11 @@ export default async function Article({
   const [channels, count] = await getChannel(params.pages);
   return (
     <div className={styles.content}>
+      <div className={styles.search_container}>
+        <Link className={styles.link} href={'/channels/search'}>
+          配信者を探す→
+        </Link>
+      </div>
       <ChannelIndex
         totalCount={count}
         channels={channels}


### PR DESCRIPTION
## Issue / Ticket

### 作業カテゴリー

- none

#69
### 作業チケット

- none

## 課題/何が起こったか

2ページ目は別ページであったため、検索画面へのリンクを配置していなかった

## 仮説/どうしてそうなったのか

トップページと同じく、検索画面へのリンクを設置する

## どういう作業を行ったか

next/linkを使い、検索画面へのリンクを設置する

## Next Point

 - none

## 変更画面のサンプル
### 変更後
![c61e4319accffe9469155fb6a7a70672](https://github.com/OKAUEND/ffxiv_vtuber_archives/assets/38197580/34d10bb4-6b1a-4556-8ee8-a020d15e98de)

## 参考資料
- none

