### PR TITLE
反映 - 縦幅を親要素準拠指定にしつつ、ローディングUIを中央より少し上に設定し、画面中央寄りに表示

### DIFF
--- a/app/_styles/loading.module.scss
+++ b/app/_styles/loading.module.scss
@@ -1,0 +1,3 @@
+.loading {
+  height: 80%;
+}

--- a/app/_styles/rootLayout.module.scss
+++ b/app/_styles/rootLayout.module.scss
@@ -21,6 +21,7 @@
 .main_container {
   margin-left: 10px;
   margin-right: 10px;
+  height: 100%;
 
   @include variables.mq(lg) {
     grid-area: 2 / 2 / 3 / 3;

--- a/app/channels/[pages]/loading.tsx
+++ b/app/channels/[pages]/loading.tsx
@@ -1,5 +1,10 @@
+import styles from '@/_styles/loading.module.scss';
 import { LoadingBasicAnimation } from '@/_components/Loading';
 
 export default function Loading() {
-  return <LoadingBasicAnimation />;
+  return (
+    <div className={styles.loading}>
+      <LoadingBasicAnimation />
+    </div>
+  );
 }


### PR DESCRIPTION
## Issue / Ticket

### 作業カテゴリー
### 作業チケット

[2ページ目などのローディングを画面中央にする](https://trello.com/c/7BaJ0aHw/72-2%E3%83%9A%E3%83%BC%E3%82%B8%E7%9B%AE%E3%81%AA%E3%81%A9%E3%81%AE%E3%83%AD%E3%83%BC%E3%83%87%E3%82%A3%E3%83%B3%E3%82%B0%E3%82%92%E7%94%BB%E9%9D%A2%E4%B8%AD%E5%A4%AE%E3%81%AB%E3%81%99%E3%82%8B)

## 課題/何が起こったか

2ページ目へのローディング中に、ローディングのUIがヘッダー近くに表示され、画面中央じゃないのに違和感を感じる

## 仮説/どうしてそうなったのか

親の要素で、heigthプロパティが指定されておらず、ローディング要素分でしか幅がないため、画面上に表示されている

## どういう作業を行ったか

最も上位にある要素のスタイルに対して、heightプロパティを100%に設定し、親の要素を継承する
Next.jsのローディングファイルの要素に対して、divで囲いそれにスタイルをつけheightプロパティを設定
ただし、100%にしてしまうと中央より下側に表示され違和感を感じるため、親に対して80%ほどを指定

## Next Point

 - ローディングUIのデザインが変わったら、ポジションの変更を行うひつようはある

## 変更画面のサンプル
### 変更前
![8bae3ecd015bf87da59cedbf5b1105fc](https://github.com/OKAUEND/ffxiv_vtuber_archives/assets/38197580/f31bee55-2806-4af1-9be8-5263fa9d5b69)

### 変更後
![edd56c87cbdf62ae3681c8776c54408b](https://github.com/OKAUEND/ffxiv_vtuber_archives/assets/38197580/6b226c0a-f16a-48bb-81a5-d702b0c380c4)

## 参考資料

- none

