### PR TITLE
反応 - 検索のカテゴリーの枠線を上辺だけにし、タイトル名を強調するためにサイズを大きくする

### DIFF
--- a/app/channels/_components/Search/SearchCategories.tsx
+++ b/app/channels/_components/Search/SearchCategories.tsx
@@ -30,8 +30,8 @@ export const SearchCategories = ({ params }: IProps) => {
     <form action="/api/form" method="GET" className={styles.container}>
       <div>
         <h2>絞り込み</h2>
-        <fieldset>
-          <legend>並び</legend>
+        <fieldset className={styles.category_field}>
+          <legend className={styles.title}>並び</legend>
           <RadioList
             categories={sortData}
             selected={selectedOption.key}
@@ -42,8 +42,8 @@ export const SearchCategories = ({ params }: IProps) => {
       </div>
       <div>
         <h2>カテゴリー検索</h2>
-        <fieldset>
-          <legend>配信開始年</legend>
+        <fieldset className={styles.category_field}>
+          <legend className={styles.title}>配信開始年</legend>
           <RadioList
             categories={years}
             selected={selectedYear.key}

--- a/app/channels/_style/search/search.module.scss
+++ b/app/channels/_style/search/search.module.scss
@@ -4,9 +4,24 @@
   width: 100%;
 }
 
+.category_field {
+  border-top: 2px solid variables.$since_text_color;
+  border-left: 0px;
+  border-bottom: 0px;
+  border-right: 0px;
+
+  margin: 0;
+
+  & .title {
+    font-size: 20px;
+    font-weight: 600;
+  }
+}
+
 .search_event {
   display: grid;
   place-items: center;
+  height: 100px;
 
   & .search {
     width: 200px;


### PR DESCRIPTION
## Issue / Ticket

### 作業カテゴリー
### 作業チケット

[検索画面のFieldSetの枠線を上だけにし、Legendの文字列のサイズを20にする](https://trello.com/c/GMpI8Tv7/71-%E6%A4%9C%E7%B4%A2%E7%94%BB%E9%9D%A2%E3%81%AEfieldset%E3%81%AE%E6%9E%A0%E7%B7%9A%E3%82%92%E4%B8%8A%E3%81%A0%E3%81%91%E3%81%AB%E3%81%97%E3%80%81legend%E3%81%AE%E6%96%87%E5%AD%97%E5%88%97%E3%81%AE%E3%82%B5%E3%82%A4%E3%82%BA%E3%82%9220%E3%81%AB%E3%81%99%E3%82%8B)

## 課題/何が起こったか

fieldセットのデフォルトスタイルだと、項目を枠線で囲われておりページ全体のイメージとして合わない
legendの項目名が小さく、項目名に見えない

## 仮説/どうしてそうなったのか

fieldset周りはデフォルトスタイルであるため

## どういう作業を行ったか

上辺だけ枠線をつけ、他の部位の枠線は0にする
legendの項目名の文字サイズを大きくする

## Next Point

 - 枠線が画面いっぱいになっている

## 変更画面のサンプル
### 変更前
![57e5f724938f12790de2ad5d704c9f4a](https://github.com/OKAUEND/ffxiv_vtuber_archives/assets/38197580/811388c7-36d0-4810-8155-597a47133170)

### 変更後
![f7c343ca27e65936c5a7f263e8f0a23f](https://github.com/OKAUEND/ffxiv_vtuber_archives/assets/38197580/d189582e-9512-495a-b474-4d8b000b6421)

## 参考資料

- none

