### PR TITLE
反映 - ログイン用のページを新規作成

### DIFF
--- a/app/_components/Sign/SignIn.tsx
+++ b/app/_components/Sign/SignIn.tsx
@@ -1,5 +1,7 @@
 'use client';
 
+import styles from './sign.module.scss';
+
 import { createClientComponentClient } from '@supabase/auth-helpers-nextjs';
 import { Provider } from '@supabase/supabase-js';
 
@@ -21,5 +23,12 @@ export const SignIn = ({ provider, children, param = '' }: IProps) => {
     });
   };
 
-  return <button onClick={() => onSignIn()}>{children}</button>;
+  return (
+    <button
+      className={`${styles.signin} ${styles.green}`}
+      onClick={() => onSignIn()}
+    >
+      {children}
+    </button>
+  );
 };

--- a/app/_components/Sign/sign.module.scss
+++ b/app/_components/Sign/sign.module.scss
@@ -1,0 +1,9 @@
+.signin {
+  width: 200px;
+  height: 40px;
+  border-radius: 10px;
+
+  & .green {
+    background-color: rgb(38, 189, 38);
+  }
+}

--- a/app/auth/_styles/signin.module.scss
+++ b/app/auth/_styles/signin.module.scss
@@ -1,0 +1,21 @@
+.container {
+  height: 80%;
+  display: grid;
+  place-items: center;
+}
+
+.content {
+  display: grid;
+  place-items: center;
+}
+
+.message {
+  margin-bottom: 15px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+.signin_text {
+  font-size: 16px;
+}

--- a/app/auth/signin/page.tsx
+++ b/app/auth/signin/page.tsx
@@ -1,0 +1,18 @@
+import styles from '@/auth/_styles/signin.module.scss';
+import { SignIn } from '@/_components/Sign';
+
+export default function AuthSignIn() {
+  return (
+    <div className={styles.container}>
+      <div className={styles.content}>
+        <div className={styles.message}>
+          <span>お持ちのアカウントを使いログインをします</span>
+          <span>※現在ログイン機能は停止中です</span>
+        </div>
+        <SignIn provider="github">
+          <span className={styles.signin_text}>Googleでログイン</span>
+        </SignIn>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Issue / Ticket

### 作業カテゴリー

#100 

### 作業チケット

[ユーザーログインページを作る。](https://trello.com/c/83IPWHQI/33-%E3%83%A6%E3%83%BC%E3%82%B6%E3%83%BC%E3%83%AD%E3%82%B0%E3%82%A4%E3%83%B3%E3%83%9A%E3%83%BC%E3%82%B8%E3%82%92%E4%BD%9C%E3%82%8B%E3%80%82)

## 課題/何が起こったか

管理者用ログインページを作成したが、そもそも管理者用パスにユーザーがアクセスするのはアンチパターンなため作り直しが必要

## 仮説/どうしてそうなったのか

管理者用ログインは管理者用ページで、ユーザー用はユーザー用で分けていたため。
ログイン認証のページを統一するために、ログインページを作成する必要がある。

## どういう作業を行ったか

authのルートに新しくログインを行うためのルート、signinを作成
pageファイルに管理者用ログインページで使われていた構成を移植

## Next Point

 - ログイン用ボタンのデザインが見た目が標準のボタンに近いため、スタイル付けを工夫したほうが良いかもしれない

## 変更画面のサンプル
![d804b0244fa00132271875d7b91402e5](https://github.com/OKAUEND/ffxiv_vtuber_archives/assets/38197580/13f6fe18-0d65-404a-802f-551d27faef8c)


## 参考資料

- none

