### PR TITLE
反映 - フィルタリングをする正規表現のワードを増やす

### DIFF
--- a/app/archives/(hooks)/useArchives.ts
+++ b/app/archives/(hooks)/useArchives.ts
@@ -46,7 +46,7 @@ export const pageSize = 25;
  */
 //配信の概要欄にクエリワードがあると、Youtubeの性質上取得されてしまうので、
 //取得後にフィルタリングするために、抽出させたい単語をまとめておいた
-const queryWorld = `FF14|FFXIV|ff14|新生|蒼天|紅蓮|漆黒|暁月`;
+const queryWorld = `FF14|FFXIV|ff14|新生|蒼天|紅蓮|漆黒|暁月|FINAL FANTASY XIV`;
 
 //---------------------------------------------------------------------------
 
@@ -86,6 +86,7 @@ const archiveListQuery = selectorFamily<YoutubeDate, QueryInput>({
     ({ channelId, beginTime }) =>
     async () => {
       const query = createQuery({ channelId, beginTime });
+      console.log({ query });
       const archives = await fetchExtend<YoutubeDate>({ url: query });
 
       return archives;

--- a/app/archives/(hooks)/useArchives.ts
+++ b/app/archives/(hooks)/useArchives.ts
@@ -86,7 +86,6 @@ const archiveListQuery = selectorFamily<YoutubeDate, QueryInput>({
     ({ channelId, beginTime }) =>
     async () => {
       const query = createQuery({ channelId, beginTime });
-      console.log({ query });
       const archives = await fetchExtend<YoutubeDate>({ url: query });
 
       return archives;


### PR DESCRIPTION
## Issue / Ticket

### 作業カテゴリー
### 作業チケット

#132

[#132 - 不具合 - 公式のもっと読み込みをし続けると、読み込みでエラーが発生するの調査](https://trello.com/c/XHIb49UY/77-132-%E4%B8%8D%E5%85%B7%E5%90%88-%E5%85%AC%E5%BC%8F%E3%81%AE%E3%82%82%E3%81%A3%E3%81%A8%E8%AA%AD%E3%81%BF%E8%BE%BC%E3%81%BF%E3%82%92%E3%81%97%E7%B6%9A%E3%81%91%E3%82%8B%E3%81%A8%E3%80%81%E8%AA%AD%E3%81%BF%E8%BE%BC%E3%81%BF%E3%81%A7%E3%82%A8%E3%83%A9%E3%83%BC%E3%81%8C%E7%99%BA%E7%94%9F%E3%81%99%E3%82%8B%E3%81%AE%E8%AA%BF%E6%9F%BB)

## 課題/何が起こったか

公式アカウントの過去アーカイブを5回遡ると、NaNのエラーが発生する

## 仮説/どうしてそうなったのか

APIから取得できているが、対象ワードに含まれている放送タイトル名になっていないため、除外されている。
そのため、本来なら配列の値があるはずなのに、配列が更新されないため画面が更新されず、
次の値を取得しようとすると、画面を更新する前にエラーとなる。

## どういう作業を行ったか

表示対象とする放送タイトル名の文言を増やし、本来表示されるはずのアーカイブを表示できるようにする

## Next Point

 - このまま対象ワードが増えた場合、ハードコードのままだと更新の手間が発生する

## 変更画面のサンプル
 
- none

## 参考資料

- none

close # 132
