### PR TITLE
変更 - Vtuber一覧から、過去アーカイブ一覧ページではなくYoutubeのチャンネルへリンクを変更

### DIFF
--- a/app/channels/_components/ChannelPanel/index.tsx
+++ b/app/channels/_components/ChannelPanel/index.tsx
@@ -15,29 +15,32 @@ export const ChannelPanel = ({ channels }: Props) => {
     <ul className={styles.container}>
       {channels.map((channel) => (
         <li key={channel.channelID} className={styles.channel_list}>
-          <Link href={`/archives/${channel.channelID}`}>
-            <div className={styles.channel_content}>
+          <div className={styles.channel_content}>
+            <Link
+              href={`https://www.youtube.com/channel/${channel.channelID}`}
+              target="_blank"
+            >
               <div className={styles.channel_icon}>
                 <Icon
                   src={`${youtubeIconURL}${channel.channelIconURL}`}
                   alt={`${channel.name}のチャンネルアイコン`}
                 />
               </div>
-              <div className={styles.channel_info}>
-                <div className={styles.info_title}>
-                  <span className={styles.info_text}>{channel.name}</span>
-                  <span className={styles.info_channelName}>
-                    {channel.channelName}
-                  </span>
-                </div>
-
-                <span className={styles.channel_since}>
-                  {DayTime(channel.beginTime)}
+            </Link>
+            <div className={styles.channel_info}>
+              <div className={styles.info_title}>
+                <span className={styles.info_text}>{channel.name}</span>
+                <span className={styles.info_channelName}>
+                  {channel.channelName}
                 </span>
               </div>
-              <div className={styles.channel_tag}></div>
+
+              <span className={styles.channel_since}>
+                {DayTime(channel.beginTime)}
+              </span>
             </div>
-          </Link>
+            <div className={styles.channel_tag}></div>
+          </div>
         </li>
       ))}
     </ul>


### PR DESCRIPTION
## Issue / Ticket

### 作業カテゴリー

#142 

### 作業チケット

#143 

## 課題/何が起こったか

ユーザーが直接Youtubeのチャンネルへ行くことができない
過去のアーカイブより、配信者のチャンネルの方が気になる

## 仮説/どうしてそうなったのか

初期の構想では、アーカイブを見ることで配信者が何をしているか興味を持ってもらう予定であった。
初期Verリリース後に幾人かのユーザーに使ってもらった結果、アーカイブからあまり判断をしないとフィードバックを得た。

## どういう作業を行ったか

Vtuberのアイコンをクリックすると、YoutubeのVtuberのチャンネルページへジャンプするようにLinkを変更

## Next Point

 - カスタムURLの対応をしていない #148 
 - Youtubeへなどのテキストを書いたほうがいいのではないか

## 変更画面のサンプル
### 変更前
![43bd31837f91c7a4315f172174d69109](https://github.com/OKAUEND/ffxiv_vtuber_archives/assets/38197580/fa2f393b-3c68-4ead-bf42-d0ca6255cec7)

### 変更後 
![37520790adc633555a05874dfa99dca6](https://github.com/OKAUEND/ffxiv_vtuber_archives/assets/38197580/f8cf40e7-b608-4e74-85e9-66f58df5312a)


## 参考資料

- none

closed # 143
