### PR TITLE
反映 - Vtuberの配信スタイルなどのカテゴリーを仮配置する

### DIFF
--- a/app/channels/_components/ChannelPanel/index.tsx
+++ b/app/channels/_components/ChannelPanel/index.tsx
@@ -40,10 +40,30 @@ export const ChannelPanel = ({ channels }: Props) => {
               </span>
             </div>
             <div className={styles.channel_tag}>
-              <div className={styles.playstyle}></div>
-              <div className={styles.user_join}></div>
-              <div className={styles.play_timezone}></div>
-              <div className={styles.datacenter}></div>
+              <div className={styles.playstyle}>
+                <div className={styles.tag}>メインストーリー</div>
+                <div className={styles.tag}>極</div>
+                <div className={styles.tag}>零式</div>
+                <div className={styles.tag}>ハウジング</div>
+                <div className={styles.tag}>地図</div>
+                <div className={styles.tag}>世界設定</div>
+                <div className={styles.tag}>PvP</div>
+              </div>
+              <div className={styles.playstyle}>
+                <div className={styles.tag}>参加型</div>
+                <div className={styles.tag}>ソロ</div>
+                <div className={styles.tag}>NPC芸</div>
+              </div>
+              <div className={styles.playstyle}>
+                <div className={styles.tag}>早朝</div>
+                <div className={styles.tag}>朝</div>
+                <div className={styles.tag}>昼</div>
+                <div className={styles.tag}>夕方</div>
+                <div className={styles.tag}>夜</div>
+                <div className={styles.tag}>深夜</div>
+              </div>
+              <div className={styles.playstyle}>Mana Chocobo</div>
+              <div className={styles.info_link}>詳しくみる→</div>
             </div>
           </div>
         </li>

--- a/app/channels/_components/ChannelPanel/index.tsx
+++ b/app/channels/_components/ChannelPanel/index.tsx
@@ -39,7 +39,12 @@ export const ChannelPanel = ({ channels }: Props) => {
                 {DayTime(channel.beginTime)}
               </span>
             </div>
-            <div className={styles.channel_tag}></div>
+            <div className={styles.channel_tag}>
+              <div className={styles.playstyle}></div>
+              <div className={styles.user_join}></div>
+              <div className={styles.play_timezone}></div>
+              <div className={styles.datacenter}></div>
+            </div>
           </div>
         </li>
       ))}

--- a/app/channels/_style/channelPanel/channelPanel.module.scss
+++ b/app/channels/_style/channelPanel/channelPanel.module.scss
@@ -37,7 +37,7 @@
   .channel_content {
     display: grid;
     grid-template-columns: 1fr 3fr;
-    grid-template-rows: 2fr 1fr;
+    width: 100%;
     grid-column-gap: 0px;
     grid-row-gap: 0px;
   }
@@ -81,19 +81,23 @@
 }
 
 .channel_tag {
-  grid-area: 2 / 2 / 3 / 3;
-  display: grid;
-  grid-template-columns: 1fr;
-  grid-template-rows: repeat(4, 1fr);
-  grid-column-gap: 0px;
-  grid-row-gap: 0px;
+  grid-area: 2 / 1 / 3 / 3;
+
+  margin: 5px;
+
+  display: flex;
+  flex-direction: column;
+  color: variables.$text_color;
+  font-size: 14px;
 
   & .playstyle {
+    display: flex;
+    flex-direction: row;
+    flex-wrap: wrap;
+    gap: 0px 5px;
   }
-  & .user_join {
-  }
-  & .play_timezone {
-  }
-  & .datacenter {
+
+  & .info_link {
+    text-align: right;
   }
 }

--- a/app/channels/_style/channelPanel/channelPanel.module.scss
+++ b/app/channels/_style/channelPanel/channelPanel.module.scss
@@ -82,4 +82,18 @@
 
 .channel_tag {
   grid-area: 2 / 2 / 3 / 3;
+  display: grid;
+  grid-template-columns: 1fr;
+  grid-template-rows: repeat(4, 1fr);
+  grid-column-gap: 0px;
+  grid-row-gap: 0px;
+
+  & .playstyle {
+  }
+  & .user_join {
+  }
+  & .play_timezone {
+  }
+  & .datacenter {
+  }
 }


### PR DESCRIPTION
## Issue / Ticket

### 作業カテゴリー

#142 

### 作業チケット

Close # 144
#144 
[#144 配信者情報を簡易表示させるために、gridで4つの縦欄を用意する](https://trello.com/c/0aY3eTVd/79-144-%E9%85%8D%E4%BF%A1%E8%80%85%E6%83%85%E5%A0%B1%E3%82%92%E7%B0%A1%E6%98%93%E8%A1%A8%E7%A4%BA%E3%81%95%E3%81%9B%E3%82%8B%E3%81%9F%E3%82%81%E3%81%AB%E3%80%81grid%E3%81%A74%E3%81%A4%E3%81%AE%E7%B8%A6%E6%AC%84%E3%82%92%E7%94%A8%E6%84%8F%E3%81%99%E3%82%8B)
[#144 上から、プレイスタイル、参加型等の視聴者との関わり、配信時間帯、DC及びサーバーの仮置きをする](https://trello.com/c/hJO1bTJm/80-144-%E4%B8%8A%E3%81%8B%E3%82%89%E3%80%81%E3%83%97%E3%83%AC%E3%82%A4%E3%82%B9%E3%82%BF%E3%82%A4%E3%83%AB%E3%80%81%E5%8F%82%E5%8A%A0%E5%9E%8B%E7%AD%89%E3%81%AE%E8%A6%96%E8%81%B4%E8%80%85%E3%81%A8%E3%81%AE%E9%96%A2%E3%82%8F%E3%82%8A%E3%80%81%E9%85%8D%E4%BF%A1%E6%99%82%E9%96%93%E5%B8%AF%E3%80%81dc%E5%8F%8A%E3%81%B3%E3%82%B5%E3%83%BC%E3%83%90%E3%83%BC%E3%81%AE%E4%BB%AE%E7%BD%AE%E3%81%8D%E3%82%92%E3%81%99%E3%82%8B)

## 課題/何が起こったか

Vtuberがどういう配信を行っているのか、一覧からでは解らないので、Vtuberが何しているか解らず選びづらい

## 仮説/どうしてそうなったのか

初期版として、まずは情報無しで実装を行ったため。

## どういう作業を行ったか

まだDBの準備が済んでいないので、まずは仮置きとして各カテゴリー要素を配置する

## Next Point

 - 見た目はまだあとで

## 変更画面のサンプル
### 変更前
![4e098224e5967eae62674c483b72b661](https://github.com/OKAUEND/ffxiv_vtuber_archives/assets/38197580/31c6331f-84db-4237-8f6e-1ae85afa80c1)


### 変更後 

![5e527c5e619bb5affd8ae646effa22d2](https://github.com/OKAUEND/ffxiv_vtuber_archives/assets/38197580/20173dd5-efdd-48df-81c0-67cb6196c793)


## 参考資料

- none


