### PR TITLE
反映 - 配信者に属性を付与するための情報を格納氏紐付ける新規テーブルを2つ作成

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "typescript": "^5.1.6"
   },
   "devDependencies": {
-    "@prisma/client": "latest",
+    "@prisma/client": "^5.0.0",
     "@testing-library/dom": "^8.20.0",
     "@testing-library/jest-dom": "^5.16.5",
     "@testing-library/react": "^13.4.0",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "node-mocks-http": "^1.12.1",
     "postcss": "^8.4.19",
     "prettier": "^2.7.1",
-    "prisma": "^4.16.1",
+    "prisma": "latest",
     "sass": "^1.62.1",
     "vite": "^4.2.1",
     "vitest": "^0.24.5",

--- a/prisma/migrations/20230801073852_/migration.sql
+++ b/prisma/migrations/20230801073852_/migration.sql
@@ -1,0 +1,23 @@
+-- CreateTable
+CREATE TABLE "PlayStyles" (
+    "id" SERIAL NOT NULL,
+    "name" TEXT NOT NULL,
+    "code" TEXT NOT NULL,
+    "type" TEXT NOT NULL,
+    "isActive" BOOLEAN NOT NULL DEFAULT true,
+    "create_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "PlayStyles_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "Tagging" (
+    "id" SERIAL NOT NULL,
+    "channel_id" INTEGER NOT NULL,
+    "tag_id" INTEGER NOT NULL,
+    "create_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "Tagging_pkey" PRIMARY KEY ("id")
+);

--- a/prisma/migrations/20230801152723_/migration.sql
+++ b/prisma/migrations/20230801152723_/migration.sql
@@ -1,0 +1,24 @@
+/*
+  Warnings:
+
+  - You are about to drop the `PlayStyles` table. If the table is not empty, all the data it contains will be lost.
+
+*/
+-- DropTable
+DROP TABLE "PlayStyles";
+
+-- CreateTable
+CREATE TABLE "Tags" (
+    "id" SERIAL NOT NULL,
+    "name" TEXT NOT NULL,
+    "code" TEXT NOT NULL,
+    "type" TEXT NOT NULL,
+    "isActive" BOOLEAN NOT NULL DEFAULT true,
+    "create_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "Tags_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "Tagging_channel_id_tag_id_idx" ON "Tagging"("channel_id", "tag_id");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -41,7 +41,7 @@ model Channel {
   beginTime      DateTime @default(now()) @db.Timestamptz(3)
 }
 
-model PlayStyles {
+model Tags {
   id        Int      @id @default(autoincrement())
   name      String
   code      String

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -58,5 +58,5 @@ model Tagging {
   create_at  DateTime @default(now()) @map("create_at")
   updated_at DateTime @updatedAt @map("updated_at")
 
-  updatedAt  DateTime @updatedAt @map("updated_at")
+  @@index([channel_id, tag_id])
 }

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -42,13 +42,13 @@ model Channel {
 }
 
 model Tags {
-  id        Int      @id @default(autoincrement())
-  name      String
-  code      String
-  type      String
-  isActive  Boolean  @default(true)
-  create_at DateTime @default(now()) @map("create_at")
-  updatedAt DateTime @updatedAt @map("updated_at")
+  id         Int      @id @default(autoincrement())
+  name       String
+  code       String
+  type       String
+  isActive   Boolean  @default(true)
+  create_at  DateTime @default(now()) @map("create_at")
+  updated_at DateTime @updatedAt @map("updated_at")
 }
 
 model Tagging {
@@ -56,5 +56,7 @@ model Tagging {
   channel_id Int
   tag_id     Int
   create_at  DateTime @default(now()) @map("create_at")
+  updated_at DateTime @updatedAt @map("updated_at")
+
   updatedAt  DateTime @updatedAt @map("updated_at")
 }

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -40,3 +40,21 @@ model Channel {
   Twitch         String
   beginTime      DateTime @default(now()) @db.Timestamptz(3)
 }
+
+model PlayStyles {
+  id        Int      @id @default(autoincrement())
+  name      String
+  code      String
+  type      String
+  isActive  Boolean  @default(true)
+  create_at DateTime @default(now()) @map("create_at")
+  updatedAt DateTime @updatedAt @map("updated_at")
+}
+
+model Tagging {
+  id         Int      @id @default(autoincrement())
+  channel_id Int
+  tag_id     Int
+  create_at  DateTime @default(now()) @map("create_at")
+  updatedAt  DateTime @updatedAt @map("updated_at")
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -864,24 +864,24 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@prisma/client@npm:latest":
-  version: 4.16.0
-  resolution: "@prisma/client@npm:4.16.0"
+"@prisma/client@npm:^5.0.0":
+  version: 5.0.0
+  resolution: "@prisma/client@npm:5.0.0"
   dependencies:
-    "@prisma/engines-version": 4.16.0-66.b20ead4d3ab9e78ac112966e242ded703f4a052c
+    "@prisma/engines-version": 4.17.0-26.6b0aef69b7cdfc787f822ecd7cdc76d5f1991584
   peerDependencies:
     prisma: "*"
   peerDependenciesMeta:
     prisma:
       optional: true
-  checksum: 67fbf8e0bd672d597433b61b65a39c58cbb2eb82e7bcac33f31215d8ca5ba48df790a20aa990c47d6dde53e0d84d1a45d07d872f772d3dd8271613abe879b5d0
+  checksum: 332c2af44e880ffc9dd1223992bf6f45910094c7a3a540cbbfdda45d6caf3e82998376338abdf85e34a12f1082ae932f2385d6396c62fe4bba7ec6b84de54466
   languageName: node
   linkType: hard
 
-"@prisma/engines-version@npm:4.16.0-66.b20ead4d3ab9e78ac112966e242ded703f4a052c":
-  version: 4.16.0-66.b20ead4d3ab9e78ac112966e242ded703f4a052c
-  resolution: "@prisma/engines-version@npm:4.16.0-66.b20ead4d3ab9e78ac112966e242ded703f4a052c"
-  checksum: 23183cab33f95e0711cd6cee7642f4beeeb77b8b0aa54b419f55097bfb96863a11a28f6509ab27fef0ea794522e188044ce850993a25c341333f8305711a255f
+"@prisma/engines-version@npm:4.17.0-26.6b0aef69b7cdfc787f822ecd7cdc76d5f1991584":
+  version: 4.17.0-26.6b0aef69b7cdfc787f822ecd7cdc76d5f1991584
+  resolution: "@prisma/engines-version@npm:4.17.0-26.6b0aef69b7cdfc787f822ecd7cdc76d5f1991584"
+  checksum: 8fcbceef3b554ee7fa404bead50be5286412a097b21723272aff298b289caf2802b01b84bb85c4c9f3b592eeac114c8d6e79db083f271dc8c54f453b4a515233
   languageName: node
   linkType: hard
 
@@ -1528,7 +1528,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "FFXIV-Vtuber-Archive@workspace:."
   dependencies:
-    "@prisma/client": latest
+    "@prisma/client": ^5.0.0
     "@supabase/auth-helpers-nextjs": ^0.7.2
     "@supabase/supabase-js": ^2.26.0
     "@testing-library/dom": ^8.20.0

--- a/yarn.lock
+++ b/yarn.lock
@@ -885,10 +885,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@prisma/engines@npm:4.16.1":
-  version: 4.16.1
-  resolution: "@prisma/engines@npm:4.16.1"
-  checksum: 7b8c1a9e20434edaa919fb24585ebff573c4ace787ea5a135dfefde3571ae31d3f0b0347397774c38be6d2e3fc0087d4e21a2720fe9f7a66ffd870e34377040f
+"@prisma/engines@npm:5.0.0":
+  version: 5.0.0
+  resolution: "@prisma/engines@npm:5.0.0"
+  checksum: 31271d85c29709059f91051d4cef7acf874014ba0128b674ca2f842e5fac61d3011e9db246dfa67ba4803081d36dbc9e31492716bab677128588343c92117b2b
   languageName: node
   linkType: hard
 
@@ -1560,7 +1560,7 @@ __metadata:
     node-mocks-http: ^1.12.1
     postcss: ^8.4.19
     prettier: ^2.7.1
-    prisma: ^4.16.1
+    prisma: latest
     react: 18.2.0
     react-dom: 18.2.0
     recoil: ^0.7.7
@@ -5870,15 +5870,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"prisma@npm:^4.16.1":
-  version: 4.16.1
-  resolution: "prisma@npm:4.16.1"
+"prisma@npm:latest":
+  version: 5.0.0
+  resolution: "prisma@npm:5.0.0"
   dependencies:
-    "@prisma/engines": 4.16.1
+    "@prisma/engines": 5.0.0
   bin:
     prisma: build/index.js
-    prisma2: build/index.js
-  checksum: eb0f43970464fbaa6ba190a714f23d00acd39dcc14fd8a7183dffc51a548cc32040cc5360415787578749862af7501a7bedcf9f2a0e64a3f82e3af402e9439d7
+  checksum: fdc62377853d25b4db664c736fd0b08d2b0c6db5752e6f6c6ec3bda77634cfb79e6f49d52d4b8f54ddb8ec9c28fc3fb0c13f95caf61085447d0929e258af9284
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Issue / Ticket

### 作業カテゴリー

#142 

### 作業チケット

#150
[#150 SupabaseのPlayStylesのテーブルにデータを注入する](https://trello.com/c/ogp4PPdX/82-150-supabase%E3%81%AEplaystyles%E3%81%AE%E3%83%86%E3%83%BC%E3%83%96%E3%83%AB%E3%81%AB%E3%83%87%E3%83%BC%E3%82%BF%E3%82%92%E6%B3%A8%E5%85%A5%E3%81%99%E3%82%8B)

## 課題/何が起こったか

Vtuberのプレイ内容における配信属性を付与するために、情報を格納するテーブルなどが存在しないので、情報を紐づけできない

## 仮説/どうしてそうなったのか

初期版として、まずは情報無しで実装を行ったため。

## どういう作業を行ったか

FFXIVにおける主なプレイの傾向のタグ情報を格納したTagsテーブル
Tagsのタグ情報をVtuberのChannelと紐付ける交差テーブルであるTaggingテーブルを作成

## Next Point

 - none

## 変更画面のサンプル

- none

## 参考資料

[Prisma  - インデックス構成](https://www.prisma.io/docs/concepts/components/prisma-schema/indexes#index-configuration)
[やさしい図解で学ぶ　中間テーブル　多対多　概念編](https://qiita.com/ramuneru/items/db43589551dd0c00fef9)
[交差テーブルには関連の意味を表す名前をつけよう](https://qiita.com/tkawa/items/dc3e313021f32fd91ca6)


