### PR TITLE
反映 - 交差テーブルを使い、Vtuberに紐づいた配信傾向/プレイスタイルの情報を取得する

### DIFF
--- a/app/_utile/prisma/index.ts
+++ b/app/_utile/prisma/index.ts
@@ -22,6 +22,14 @@ export const getChannelOffset = async (
       },
       { beginTime: 'desc' },
     ],
+    include: {
+      tags: {
+        include: {
+          tags: true,
+        },
+      },
+    },
+
   });
 
   return res;

--- a/app/_utile/prisma/index.ts
+++ b/app/_utile/prisma/index.ts
@@ -13,7 +13,7 @@ const prisma = new PrismaClient({
 export const getChannelOffset = async (
   offset = 0
 ): Promise<HikasenVtuber[]> => {
-  const res = await prisma.channel.findMany({
+  const channels = await prisma.channel.findMany({
     take: 20,
     skip: offset,
     orderBy: [
@@ -29,10 +29,22 @@ export const getChannelOffset = async (
         },
       },
     },
-
   });
 
-  return res;
+  const result = channels.map((channel) => {
+    return {
+      ...channel,
+      tags: channel.tags.map((tag) => {
+        return {
+          name: tag.tags.name,
+          code: tag.tags.code,
+          type: tag.tags.type,
+        };
+      }),
+    };
+  });
+
+  return result;
 };
 
 /**

--- a/prisma/migrations/20230801171237_/migration.sql
+++ b/prisma/migrations/20230801171237_/migration.sql
@@ -1,0 +1,17 @@
+/*
+  Warnings:
+
+  - The primary key for the `Tagging` table will be changed. If it partially fails, the table could be left without primary key constraint.
+  - You are about to drop the column `id` on the `Tagging` table. All the data in the column will be lost.
+
+*/
+-- AlterTable
+ALTER TABLE "Tagging" DROP CONSTRAINT "Tagging_pkey",
+DROP COLUMN "id",
+ADD CONSTRAINT "Tagging_pkey" PRIMARY KEY ("channel_id", "tag_id");
+
+-- AddForeignKey
+ALTER TABLE "Tagging" ADD CONSTRAINT "Tagging_channel_id_fkey" FOREIGN KEY ("channel_id") REFERENCES "Channel"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Tagging" ADD CONSTRAINT "Tagging_tag_id_fkey" FOREIGN KEY ("tag_id") REFERENCES "Tags"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -28,35 +28,39 @@ model User {
 }
 
 model Channel {
-  id             Int      @id @default(autoincrement())
-  channelID      String   @unique
+  id             Int       @id @default(autoincrement())
+  channelID      String    @unique
   name           String
   channelName    String
   channelIconURL String
-  isOfficial     Boolean  @default(false)
+  isOfficial     Boolean   @default(false)
   dataCenter     String
   server         String
   Twitter        String
   Twitch         String
-  beginTime      DateTime @default(now()) @db.Timestamptz(3)
+  beginTime      DateTime  @default(now()) @db.Timestamptz(3)
+  tags           Tagging[]
 }
 
 model Tags {
-  id         Int      @id @default(autoincrement())
+  id         Int       @id @default(autoincrement())
   name       String
   code       String
   type       String
-  isActive   Boolean  @default(true)
-  create_at  DateTime @default(now()) @map("create_at")
-  updated_at DateTime @updatedAt @map("updated_at")
+  isActive   Boolean   @default(true)
+  create_at  DateTime  @default(now()) @map("create_at")
+  updated_at DateTime  @updatedAt @map("updated_at")
+  channels   Tagging[]
 }
 
 model Tagging {
-  id         Int      @id @default(autoincrement())
+  channel    Channel  @relation(fields: [channel_id], references: [id])
   channel_id Int
+  tags       Tags     @relation(fields: [tag_id], references: [id])
   tag_id     Int
   create_at  DateTime @default(now()) @map("create_at")
   updated_at DateTime @updatedAt @map("updated_at")
 
+  @@id([channel_id, tag_id])
   @@index([channel_id, tag_id])
 }


### PR DESCRIPTION
## Issue / Ticket

### 作業カテゴリー

#142 

### 作業チケット

#150
[#150 PrismaでVtuberの情報と共に、プレイスタイルの情報もテーブルをJoinして取得する](https://trello.com/c/5DRIIX7x/85-150-prisma%E3%81%A7vtuber%E3%81%AE%E6%83%85%E5%A0%B1%E3%81%A8%E5%85%B1%E3%81%AB%E3%80%81%E3%83%97%E3%83%AC%E3%82%A4%E3%82%B9%E3%82%BF%E3%82%A4%E3%83%AB%E3%81%AE%E6%83%85%E5%A0%B1%E3%82%82%E3%83%86%E3%83%BC%E3%83%96%E3%83%AB%E3%82%92join%E3%81%97%E3%81%A6%E5%8F%96%E5%BE%97%E3%81%99%E3%82%8B)

## 課題/何が起こったか

交差テーブルを使い、配信者傾向とプレイスタイルをVtuber一覧に表示したいので、同時に取得する必要性がある

## 仮説/どうしてそうなったのか

次の作業として、既存処理でVtuber情報を取得している処理へ、同時にする処理を追加する。
includeで交差テーブル越しに取得できる。
ただし、交差テーブルの情報→紐づいてる先のテーブル情報と多重ネスト状態になっているので、
必要な情報だけでネストを平坦にする必要性がある。

## どういう作業を行ったか

prismaのfindManyの中にincludeで交差テーブルを指定し、さらにネストで対象テーブルの情報を取得する。

## Next Point

 - none

## 変更画面のサンプル

- none

## 参考資料

[Prisma - Many-to-many relations](https://www.prisma.io/docs/concepts/components/prisma-schema/relations/many-to-many-relations)


