### PR TITLE
反映 - ネストされていた配信傾向/プレイスタイルのプロパティを、カテゴリー毎に分類し直す

### DIFF
--- a/app/(types)/index.ts
+++ b/app/(types)/index.ts
@@ -9,4 +9,11 @@ export interface HikasenVtuber {
   dataCenter: string;
   server: string;
   beginTime: string | Date;
+  tags: { content: Tag[]; party: Tag[]; timezone: Tag[] };
+}
+
+export interface Tag {
+  id: number;
+  name: string;
+  code: string;
 }


### PR DESCRIPTION
## Issue / Ticket

### 作業カテゴリー

#142 

### 作業チケット

#150
[#150 交差テーブル経由で取得した情報を、カテゴリー毎に分類し、配列へ変換をする](https://trello.com/c/qhBtmiCp/87-150-%E4%BA%A4%E5%B7%AE%E3%83%86%E3%83%BC%E3%83%96%E3%83%AB%E7%B5%8C%E7%94%B1%E3%81%A7%E5%8F%96%E5%BE%97%E3%81%97%E3%81%9F%E6%83%85%E5%A0%B1%E3%82%92%E3%80%81%E3%82%AB%E3%83%86%E3%82%B4%E3%83%AA%E3%83%BC%E6%AF%8E%E3%81%AB%E5%88%86%E9%A1%9E%E3%81%97%E3%80%81%E9%85%8D%E5%88%97%E3%81%B8%E5%A4%89%E6%8F%9B%E3%82%92%E3%81%99%E3%82%8B)

## 課題/何が起こったか

DBより取得した値が多重ネスト状態で、更に交差テーブルの不要な情報も多く含まれており、表示するだけでは使わない値も多い。

## 仮説/どうしてそうなったのか

Prismaの交差テーブルの仕様により、Joinした値は多重ネスト状態で取得される。
そのため、公式のドキュメントにも使用する場合は配列操作などで必要な情報だけで平坦にする必要があると記載されている。
また、今回作成した配信傾向/プレイスタイルテーブルは、カテゴリーごとに異なる種類が存在するため、表示等で使う場合はカテゴリーごとに分類されている方が、値を扱いやすい。

## どういう作業を行ったか

convert関数を作成し、その中で取得したTagsをループで回し種類毎に分類をする。
最終的に、それらをプロパティにセットすることで、カテゴリー毎に必要な情報を扱えるようにした。

## Next Point

 - none

## 変更画面のサンプル

- none

## 参考資料

[Prisma - Modeling and querying many-to-many relations(該当ページの下の方)](https://www.prisma.io/docs/guides/other/troubleshooting-orm/help-articles/working-with-many-to-many-relations#explicit-relations)


