### PR TITLE
反映 - Vtuberパネルに、配信傾向/プレイスタイルを表示する

### DIFF
--- a/app/_utile/prisma/index.ts
+++ b/app/_utile/prisma/index.ts
@@ -89,18 +89,7 @@ export const getChannelOffset = async (
     },
   });
 
-  const result = channels.map((channel) => {
-    return {
-      ...channel,
-      tags: channel.tags.map((tag) => {
-        return {
-          name: tag.tags.name,
-          code: tag.tags.code,
-          type: tag.tags.type,
-        };
-      }),
-    };
-  });
+  const result = convertTags(channels);
 
   return result;
 };
@@ -126,7 +115,7 @@ export const getChannelWhereOffset = async (
   query: Prisma.ChannelWhereInput,
   orderBy: Prisma.SortOrder
 ): Promise<HikasenVtuber[]> => {
-  const res = await prisma.channel.findMany({
+  const channels = await prisma.channel.findMany({
     take: 20,
     skip: offset,
     where: {
@@ -134,9 +123,18 @@ export const getChannelWhereOffset = async (
       ...query,
     },
     orderBy: [{ beginTime: orderBy }],
+    include: {
+      tags: {
+        include: {
+          tags: true,
+        },
+      },
+    },
   });
 
-  return res;
+  const result = convertTags(channels);
+
+  return result;
 };
 
 /**

--- a/app/channels/_components/ChannelPanel/index.tsx
+++ b/app/channels/_components/ChannelPanel/index.tsx
@@ -56,9 +56,8 @@ export const ChannelPanel = ({ channels }: Props) => {
                 ))}
               </ul>
               <div className={styles.playstyle}>
-                
+                {`${channel.dataCenter} ${channel.server}`}
               </div>
-              <div className={styles.playstyle}>Mana Chocobo</div>
               <div className={styles.info_link}>詳しくみる→</div>
             </div>
           </div>

--- a/app/channels/_components/ChannelPanel/index.tsx
+++ b/app/channels/_components/ChannelPanel/index.tsx
@@ -40,27 +40,23 @@ export const ChannelPanel = ({ channels }: Props) => {
               </span>
             </div>
             <div className={styles.channel_tag}>
+              <ul className={styles.playstyle}>
+                {channel.tags.content.map((content) => (
+                  <li key={content.id}>{content.name}</li>
+                ))}
+              </ul>
+              <ul className={styles.playstyle}>
+                {channel.tags.party.map((party) => (
+                  <li key={party.id}>{party.name}</li>
+                ))}
+              </ul>
+              <ul className={styles.playstyle}>
+                {channel.tags.timezone.map((timezone) => (
+                  <li key={timezone.id}>{timezone.name}</li>
+                ))}
+              </ul>
               <div className={styles.playstyle}>
-                <div className={styles.tag}>メインストーリー</div>
-                <div className={styles.tag}>極</div>
-                <div className={styles.tag}>零式</div>
-                <div className={styles.tag}>ハウジング</div>
-                <div className={styles.tag}>地図</div>
-                <div className={styles.tag}>世界設定</div>
-                <div className={styles.tag}>PvP</div>
-              </div>
-              <div className={styles.playstyle}>
-                <div className={styles.tag}>参加型</div>
-                <div className={styles.tag}>ソロ</div>
-                <div className={styles.tag}>NPC芸</div>
-              </div>
-              <div className={styles.playstyle}>
-                <div className={styles.tag}>早朝</div>
-                <div className={styles.tag}>朝</div>
-                <div className={styles.tag}>昼</div>
-                <div className={styles.tag}>夕方</div>
-                <div className={styles.tag}>夜</div>
-                <div className={styles.tag}>深夜</div>
+                
               </div>
               <div className={styles.playstyle}>Mana Chocobo</div>
               <div className={styles.info_link}>詳しくみる→</div>


### PR DESCRIPTION
## Issue / Ticket

### 作業カテゴリー

#142 

### 作業チケット

Closes #150
[#150 テーブルより取得した値をVtuber一覧に簡易表示する](https://trello.com/c/jBjqd4Q3/86-150-%E3%83%86%E3%83%BC%E3%83%96%E3%83%AB%E3%82%88%E3%82%8A%E5%8F%96%E5%BE%97%E3%81%97%E3%81%9F%E5%80%A4%E3%82%92vtuber%E4%B8%80%E8%A6%A7%E3%81%AB%E7%B0%A1%E6%98%93%E8%A1%A8%E7%A4%BA%E3%81%99%E3%82%8B)
[#150 DCとサーバー情報を表示する](https://trello.com/c/9dahi65X/88-150-dc%E3%81%A8%E3%82%B5%E3%83%BC%E3%83%90%E3%83%BC%E6%83%85%E5%A0%B1%E3%82%92%E8%A1%A8%E7%A4%BA%E3%81%99%E3%82%8B)

## 課題/何が起こったか

配信傾向/プレイスタイルの情報が取得可能となったので、Vtuber一覧に表示させてわかりやすくする必要がある

## 仮説/どうしてそうなったのか

取得ができたので、仮置きしていた要素と置き換えて実際に表示する

## どういう作業を行ったか

tagsプロパティの`content`、`party`、`timezone`は配列であるので、JSXのループで回し要素を表示する。
DC及びサーバーは元より`channels`に含まれていた情報なので、そのままプロパティの内容を表示する

## Next Point

 - 今は1名の配信者しか紐付けれていないので、今後は多くの配信者で情報の紐づけを行う必要がある

## 変更画面のサンプル
### 変更前
![c61e4319accffe9469155fb6a7a70672](https://github.com/OKAUEND/ffxiv_vtuber_archives/assets/38197580/6e8955cf-5f12-4ea2-9ed3-f0f0f57b80f1)

### 変更後
![ccec0373246c9289d53a7985f565a609](https://github.com/OKAUEND/ffxiv_vtuber_archives/assets/38197580/575d3d65-6a6d-4bc1-b18b-34d04a03a946)


## 参考資料

- none


