### PR TITLE
反映 - DBの型にタグ情報テーブルを追加したため、タグ情報テーブルの型を追加する必要がある

### DIFF
--- a/app/api/control/route.ts
+++ b/app/api/control/route.ts
@@ -1,13 +1,17 @@
 import { fetchExtend } from '@/_utile/fetch';
 import { HikasenVtuber } from '@/(types)/';
+import { Tagging } from '@prisma/client';
 
 import prisma from '@/_utile/prisma';
 
 export async function GET() {
   const url = `${process.env.CHANNELLIST_URL}`;
 
-  const gas = await fetchExtend<HikasenVtuber[]>({ url, store: false });
-  const convertChannels: HikasenVtuber[] = gas.map((channel) => {
+  const gas = await fetchExtend<HikasenVtuber<Tagging>[]>({
+    url,
+    store: false,
+  });
+  const convertChannels: HikasenVtuber<Tagging>[] = gas.map((channel) => {
     //スプレッドシートからの取得ではJTCではなくUTCになっているため、9時間をたしてJTCにする
     const time = new Date(channel.beginTime);
     time.setHours(time.getHours() + 9);
@@ -32,7 +36,7 @@ export async function GET() {
 }
 
 export async function POST(request: Request) {
-  const channel: HikasenVtuber[] = await request.json();
+  const channel: HikasenVtuber<Tagging>[] = await request.json();
   await prisma.channel.createMany({
     data: channel,
     skipDuplicates: true,

--- a/app/channels/__tests__/_mock/index.ts
+++ b/app/channels/__tests__/_mock/index.ts
@@ -1,21 +1,27 @@
 import { HikasenVtuber } from '@/(types)';
+import { Tagging } from '@prisma/client';
 
-const HikasenVtuberResourceFactory = (name: string): HikasenVtuber => {
+const HikasenVtuberResourceFactory = (
+  name: string
+): HikasenVtuber<Tagging[]> => {
   return {
     channelID: name,
-    channelIconID: '/public/mock/image/icon.png',
+    channelIconURL: '/public/mock/image/icon.png',
     channelName: `${name} Channel`,
     name: name,
-    twitter: '',
-    twitch: '',
-    ffxiv: {
-      dataCenter: 'test',
-      server: 'test',
-    },
+    Twitter: '',
+    Twitch: '',
+    dataCenter: 'test',
+    server: 'test',
+    isOfficial: false,
+    beginTime: '',
+    tags: [],
   };
 };
 
-export const createHikasenVtuberData = (name: string): HikasenVtuber[] => {
+export const createHikasenVtuberData = (
+  name: string
+): HikasenVtuber<Tagging[]>[] => {
   const array = Array.from({ length: 5 }, (_, index) =>
     HikasenVtuberResourceFactory(`${name}${index}`)
   );

--- a/app/channels/_components/ChannelIndex/index.tsx
+++ b/app/channels/_components/ChannelIndex/index.tsx
@@ -2,10 +2,10 @@ import { ErrorBoundaryExtended } from '@/_components/ErrorBoundary';
 import { ChannelSearchParams } from '@/channels/(types)';
 import { ChannelPanel } from '../ChannelPanel';
 import { Pagination } from '@/_components/Pagination';
-import { HikasenVtuber } from '@/(types)';
+import { HikasenVtuber, Tags } from '@/(types)';
 
 interface IProps {
-  channels: HikasenVtuber[];
+  channels: HikasenVtuber<Tags>[];
   page?: string;
   totalCount: number;
   params?: ChannelSearchParams;

--- a/app/channels/_components/ChannelPanel/index.tsx
+++ b/app/channels/_components/ChannelPanel/index.tsx
@@ -2,11 +2,11 @@ import Link from 'next/link';
 
 import styles from '@/channels/_style/channelPanel/channelPanel.module.scss';
 import { Icon } from '@/_components/Elements/Icon';
-import { HikasenVtuber } from '@/(types)';
+import { HikasenVtuber, Tags } from '@/(types)';
 import DayTime from '@/_utile/convert/DayTime';
 
 type Props = {
-  channels: HikasenVtuber[];
+  channels: HikasenVtuber<Tags>[];
 };
 
 export const ChannelPanel = ({ channels }: Props) => {

--- a/app/channels/_lib/api/getChannel.ts
+++ b/app/channels/_lib/api/getChannel.ts
@@ -1,9 +1,9 @@
-import { HikasenVtuber } from '@/(types)/';
+import { HikasenVtuber, Tags } from '@/(types)/';
 import { getChannelCount, getChannelOffset } from '@/_utile/prisma';
 
 export const getChannel = async (
   offset: string
-): Promise<readonly [HikasenVtuber[], number]> => {
+): Promise<readonly [HikasenVtuber<Tags>[], number]> => {
   //モバイルでのみやすさも考慮し、20件ほどに絞る。10件だけはPCやタブレットで見るには少なすぎる
   const BASE_QUERY_COUNT = 20;
   //何も指定がないときのためのガード構文

--- a/app/control/(hooks)/useAdminControl.ts
+++ b/app/control/(hooks)/useAdminControl.ts
@@ -2,12 +2,12 @@ import { atom, selector, useRecoilValue, useRecoilCallback } from 'recoil';
 
 import { fetchExtend } from '@/_utile/fetch';
 import { Channels, FilterOption } from '@/control/(types)';
-import { HikasenVtuber } from '@/(types)';
+import { HikasenVtuber, Tags } from '@/(types)';
 import { useCallback } from 'react';
 
-type ControlChannel = HikasenVtuber & { isAllMatched: boolean };
+type ControlChannel = HikasenVtuber<Tags> & { isAllMatched: boolean };
 
-const updateChannel = async (channels: HikasenVtuber[]) => {
+const updateChannel = async (channels: HikasenVtuber<Tags>[]) => {
   await fetchExtend({
     method: 'POST',
     url: '/api/control/',
@@ -16,7 +16,7 @@ const updateChannel = async (channels: HikasenVtuber[]) => {
   });
 };
 
-const selectedChannel = atom<Map<string, HikasenVtuber>>({
+const selectedChannel = atom<Map<string, HikasenVtuber<Tags>>>({
   key: 'store/selected-channel',
   default: new Map([]),
 });
@@ -40,7 +40,7 @@ const channelQuery = selector({
   },
 });
 
-export const channelMapToArray = selector<HikasenVtuber[]>({
+export const channelMapToArray = selector<HikasenVtuber<Tags>[]>({
   key: 'convert/selected-channel',
   get: ({ get }) => {
     const mapChannels = get(selectedChannel);
@@ -111,7 +111,7 @@ export const useAdminControl = () => {
   const cacheChannel = useRecoilCallback(
     ({ set }) =>
       (channel: ControlChannel) => {
-        const tmpChannel: HikasenVtuber = {
+        const tmpChannel: HikasenVtuber<Tags> = {
           channelID: channel.channelID,
           channelIconURL: channel.channelIconURL,
           channelName: channel.channelName,

--- a/app/control/(types)/index.ts
+++ b/app/control/(types)/index.ts
@@ -1,8 +1,8 @@
-import { HikasenVtuber } from '@/(types)';
+import { HikasenVtuber, Tags } from '@/(types)';
 
 export interface Channels {
-  gas: HikasenVtuber[];
-  db: HikasenVtuber[];
+  gas: HikasenVtuber<Tags>[];
+  db: HikasenVtuber<Tags>[];
 }
 
 /**

--- a/app/control/__tests__/components/channelControl.test.tsx
+++ b/app/control/__tests__/components/channelControl.test.tsx
@@ -10,7 +10,7 @@ describe('Control Channel Component UI TEST', () => {
     return createHikasenVtuberData('Control');
   });
   test('Hookから取得した要素をリストで表示できているか', () => {
-    render(<ChannelControl />);
+    render(<ChannelControl isAdmin={true} />);
 
     const list = screen.getByRole('list');
 
@@ -19,7 +19,7 @@ describe('Control Channel Component UI TEST', () => {
     expect(items.length).toBe(5);
   });
   test('配信者名を表示できているか', () => {
-    render(<ChannelControl />);
+    render(<ChannelControl isAdmin={true} />);
 
     const list = screen.getByRole('list');
 
@@ -31,7 +31,7 @@ describe('Control Channel Component UI TEST', () => {
     expect(heads.length).toEqual(5);
   });
   test('配信者のアイコンは表示出来ているか', () => {
-    render(<ChannelControl />);
+    render(<ChannelControl isAdmin={true} />);
 
     const imageElement = screen.getAllByAltText(/のチャンネルアイコン$/);
     expect(imageElement.length).toEqual(5);

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,11 +1,13 @@
 import styles from '@/_styles/rootPage.module.scss';
 
 import { ChannelIndex } from '@/channels/_components/ChannelIndex';
-import { HikasenVtuber } from './(types)';
+import { HikasenVtuber, Tags } from './(types)';
 import { getChannelOffset, getChannelCount } from './_utile/prisma';
 import Link from 'next/link';
 
-const getChannel = async (): Promise<readonly [HikasenVtuber[], number]> => {
+const getChannel = async (): Promise<
+  readonly [HikasenVtuber<Tags>[], number]
+> => {
   const channels = await getChannelOffset(0);
   const count = await getChannelCount();
 


### PR DESCRIPTION
## Issue / Ticket

### 作業カテゴリー

#142 

### 作業チケット

- none

## 課題/何が起こったか

配信者にプレイスタイルや配信傾向などを紐づけたため、コーディングで参照するために変更が必要であった。

## 仮説/どうしてそうなったのか

PrismaのModelに合わせて、TypeScriptの型も合わせる

## どういう作業を行ったか

tagsのプロパティを追加し、HikasenVtuberの型を使用している箇所の型にジェネリクスを設定する

## Next Point

 -Prismaの型を使えばいいのではないかとの懸念はある

## 変更画面のサンプル

- none

## 参考資料

- none


