### PR TITLE
反映 - View側で表示するために、DBの構成に合わせた内容へ変更をする

### DIFF
--- a/app/_utile/convert/index.ts
+++ b/app/_utile/convert/index.ts
@@ -1,0 +1,1 @@
+export { convertTaggingToTags, convertTagsToCategoryTags } from './tags';

--- a/app/_utile/convert/tags.ts
+++ b/app/_utile/convert/tags.ts
@@ -59,3 +59,54 @@ export const convertTaggingToTags = (channels): HikasenVtuber<Tags>[] => {
     };
   });
 };
+
+export const convertTagsToCategoryTags = (tags: PrismaTags[] | Tag[]): Tags => {
+  //DBのタグ情報は、1つのテーブルに入っているので、種類毎に使いやすいように分割する
+  const contents: Tag[] = [];
+  const party: Tag[] = [];
+  const timezone: Tag[] = [];
+
+  tags.forEach((tag) => {
+    //ソートのために必要なID、表示に必要な名前、コードのみにオブジェクトを限定する
+    const convert = {
+      id: tag.id,
+      name: tag.name,
+      code: tag.code,
+      type: tag.type,
+    };
+
+    //見やすいようにSwitch文で切り分ける
+    switch (tag.type) {
+      case 'content':
+        contents.push(convert);
+        break;
+      case 'play':
+        party.push(convert);
+        break;
+      case 'timezone':
+        timezone.push(convert);
+        break;
+      default:
+        break;
+    }
+  });
+
+  //サーバー登録順は必ずしもID順に並んでいないので、ID順に並べ直させる
+  contents.sort((a, b) => {
+    return a.id - b.id;
+  });
+  party.sort((a, b) => {
+    return a.id - b.id;
+  });
+  timezone.sort((a, b) => {
+    return a.id - b.id;
+  });
+
+  const convertTags = {
+    content: contents,
+    party: party,
+    timezone: timezone,
+  };
+
+  return convertTags;
+};

--- a/app/_utile/prisma/index.ts
+++ b/app/_utile/prisma/index.ts
@@ -92,9 +92,7 @@ export const getChannelWhereOffset = async (
     },
   });
 
-  const result = convertTaggingToTags(channels);
-
-  return result;
+  return convertTaggingToTags(channels);
 };
 
 /**

--- a/app/channels/(hooks)/Search/useChannelSearchCategories.ts
+++ b/app/channels/(hooks)/Search/useChannelSearchCategories.ts
@@ -1,5 +1,6 @@
+import { convertTagsToCategoryTags } from '@/_utile/convert';
 import { ChannelSearchParams } from '@/channels/(types)';
-import { Tags } from '@/(types)';
+import { getTags } from '@/channels/_lib/api/getTags';
 
 import { atom, useRecoilCallback, useRecoilValue } from 'recoil';
 
@@ -89,5 +90,5 @@ export const useInitChannelSearch = () => {
 };
 
 export const useTags = () => {
-  return tags;
+  return convertTagsToCategoryTags(getTags());
 };

--- a/app/channels/(types)/index.ts
+++ b/app/channels/(types)/index.ts
@@ -1,4 +1,19 @@
+import { Prisma } from '@prisma/client';
+
 export interface ChannelSearchParams {
   orderBy: string;
   year: string;
+  content: string[];
+  play: string[];
+  timezone: [];
+}
+
+export interface PrismaQuery {
+  query: {
+    content: Prisma.ChannelWhereInput;
+    play: Prisma.ChannelWhereInput;
+    timeZone: Prisma.ChannelWhereInput;
+  };
+  year: Prisma.ChannelWhereInput;
+  orderBy: Prisma.SortOrder;
 }

--- a/app/channels/_lib/api/getTags.ts
+++ b/app/channels/_lib/api/getTags.ts
@@ -1,148 +1,143 @@
-import { Tags } from '@/(types)';
+import { Tag } from '@/(types)';
+import { convertTagsToCategoryTags } from '@/_utile/convert/tags';
 
-export const tags: Tags = {
-  content: [
-    {
-      id: 1,
-      name: 'ストーリー',
-      code: 'story',
-      type: 'content',
-    },
-    {
-      id: 2,
-      name: '極・幻',
-      code: 'primal',
-      type: 'content',
-    },
-    {
-      id: 3,
-      name: '高難易度',
-      code: 'raid',
-      type: 'content',
-    },
-    {
-      id: 4,
-      name: 'ハウジング',
-      code: 'housing',
-      type: 'content',
-    },
-    {
-      id: 5,
-      name: '世界設定',
-      code: 'lore',
-      type: 'content',
-    },
-    {
-      id: 6,
-      name: '地図',
-      code: 'treasure',
-      type: 'content',
-    },
-    {
-      id: 7,
-      name: 'SS',
-      code: 'treasure',
-      type: 'content',
-    },
-    {
-      id: 8,
-      name: 'ギャザクラ',
-      code: 'disciples',
-      type: 'content',
-    },
-    {
-      id: 9,
-      name: 'ユーザーイベント',
-      code: 'event',
-      type: 'content',
-    },
-    {
-      id: 10,
-      name: 'エウレカ・ボズヤ系',
-      code: 'filed',
-      type: 'content',
-    },
-    {
-      id: 11,
-      name: 'PvP',
-      code: 'pvp',
-      type: 'content',
-    },
-    {
-      id: 12,
-      name: 'ダンジョン',
-      code: 'dungeon',
-      type: 'content',
-    },
-  ],
-  party: [
-    {
-      id: 1,
-      name: '参加型',
-      code: 'party',
-      type: 'play',
-    },
-    {
-      id: 2,
-      name: 'ソロ',
-      code: 'solo',
-      type: 'play',
-    },
-    {
-      id: 3,
-      name: 'npc芸歓迎',
-      code: 'npcplay',
-      type: 'play',
-    },
-    {
-      id: 4,
-      name: '攻略',
-      code: 'raiders',
-      type: 'play',
-    },
-    {
-      id: 5,
-      name: '周回',
-      code: 'farm',
-      type: 'play',
-    },
-  ],
-  timezone: [
-    {
-      id: 1,
-      name: '早朝',
-      code: 'earylmorning',
-      type: 'timezone',
-    },
-    {
-      id: 2,
-      name: '朝',
-      code: 'morning',
-      type: 'timezone',
-    },
-    {
-      id: 3,
-      name: '昼',
-      code: 'midday',
-      type: 'timezone',
-    },
-    {
-      id: 4,
-      name: '夕方',
-      code: 'evening',
-      type: 'timezone',
-    },
-    {
-      id: 5,
-      name: '夜',
-      code: 'night',
-      type: 'timezone',
-    },
-    {
-      id: 6,
-      name: '深夜',
-      code: 'midnight',
-      type: 'timezone',
-    },
-  ],
-};
+export const tags: Tag[] = [
+  {
+    id: 1,
+    name: 'ストーリー',
+    code: 'story',
+    type: 'content',
+  },
+  {
+    id: 2,
+    name: '極・幻',
+    code: 'primal',
+    type: 'content',
+  },
+  {
+    id: 3,
+    name: '高難易度',
+    code: 'raid',
+    type: 'content',
+  },
+  {
+    id: 4,
+    name: 'ハウジング',
+    code: 'housing',
+    type: 'content',
+  },
+  {
+    id: 5,
+    name: '世界設定',
+    code: 'lore',
+    type: 'content',
+  },
+  {
+    id: 6,
+    name: '地図',
+    code: 'treasure',
+    type: 'content',
+  },
+  {
+    id: 7,
+    name: 'SS',
+    code: 'treasure',
+    type: 'content',
+  },
+  {
+    id: 8,
+    name: 'ギャザクラ',
+    code: 'disciples',
+    type: 'content',
+  },
+  {
+    id: 9,
+    name: 'ユーザーイベント',
+    code: 'event',
+    type: 'content',
+  },
+  {
+    id: 10,
+    name: 'エウレカ・ボズヤ系',
+    code: 'filed',
+    type: 'content',
+  },
+  {
+    id: 11,
+    name: 'PvP',
+    code: 'pvp',
+    type: 'content',
+  },
+  {
+    id: 12,
+    name: 'ダンジョン',
+    code: 'dungeon',
+    type: 'content',
+  },
+  {
+    id: 13,
+    name: '参加型',
+    code: 'party',
+    type: 'play',
+  },
+  {
+    id: 14,
+    name: 'ソロ',
+    code: 'solo',
+    type: 'play',
+  },
+  {
+    id: 15,
+    name: 'npc芸歓迎',
+    code: 'npcplay',
+    type: 'play',
+  },
+  {
+    id: 16,
+    name: '攻略',
+    code: 'raiders',
+    type: 'play',
+  },
+  {
+    id: 17,
+    name: '周回',
+    code: 'farm',
+    type: 'play',
+  },
+  {
+    id: 18,
+    name: '早朝',
+    code: 'earylmorning',
+    type: 'timezone',
+  },
+  {
+    id: 19,
+    name: '朝',
+    code: 'morning',
+    type: 'timezone',
+  },
+  {
+    id: 20,
+    name: '昼',
+    code: 'midday',
+    type: 'timezone',
+  },
+  {
+    id: 21,
+    name: '夕方',
+    code: 'evening',
+    type: 'timezone',
+  },
+  {
+    id: 22,
+    name: '夜',
+    code: 'night',
+    type: 'timezone',
+  },
+  {
+    id: 23,
+    name: '深夜',
+    code: 'midnight',
+    type: 'timezone',
+  },
+];

--- a/app/channels/_lib/api/getTags.ts
+++ b/app/channels/_lib/api/getTags.ts
@@ -141,3 +141,7 @@ export const tags: Tag[] = [
     type: 'timezone',
   },
 ];
+
+export const getTags = () => {
+  return tags;
+};


### PR DESCRIPTION
## Issue / Ticket

### 作業カテゴリー

#142 

### 作業チケット

- none

## 課題/何が起こったか

コンポーネントのViewで表示するために、前に作ったタグ情報の一覧がDBと違っており表示処理が面倒
前に作ったタグ情報の一覧がDBの構成と違っていたため、タグ情報一覧の値を使い処理するロジックが共通化できない

## 仮説/どうしてそうなったのか

完全にロジックが固まる前に作っていたため、DBと構成が違うようなことになった。
また、DBから値を取得するためのロジックを、最初はRoute Handler経由にしていた所、思ったより取得に時間がかかったため、
その部分のロジックをどのようにするかは後回しにしたため

## どういう作業を行ったか

DBと同じ構成にする

## Next Point

 - 関係のあるコミットをまとめたら、大きなPRとなった気がする部分

## 変更画面のサンプル

- none 

## 参考資料

- none



