### PR TITLE
反映 - LEFTJOINを使い、検索を行いたいテーブルをJOINすることで、タグ検索を実現する

### DIFF
--- a/app/_utile/prisma/index.ts
+++ b/app/_utile/prisma/index.ts
@@ -2,6 +2,7 @@ import { HikasenVtuber, Tags, Tag } from '@/(types)';
 import { PrismaClient, Prisma } from '@prisma/client';
 
 import { convertTaggingToTags } from '@/_utile/convert';
+import { PrismaQuery } from '@/channels/(types)';
 
 export const prisma = new PrismaClient({
   log: ['query', 'error', 'info', 'warn'],
@@ -56,33 +57,17 @@ export const getChannelCount = async () => {
  */
 export const getChannelWhereOffset = async (
   offset = 0,
-  query: Prisma.ChannelWhereInput,
-  orderBy: Prisma.SortOrder
+  query: PrismaQuery
 ): Promise<HikasenVtuber<Tags>[]> => {
-  const tagging_channels = await prisma.tagging.findMany({
-    distinct: ['channel_id'],
-    where: {
-      OR: [{ tag_id: 13 }, { tag_id: 23 }, { tag_id: 3 }],
-      channel: {
-        isOfficial: false,
-      },
-    },
-    orderBy: [{ channel: { beginTime: 'desc' } }],
-    select: {
-      channel: {
-        include: {},
-      },
-    },
-  });
-
   const channels = await prisma.channel.findMany({
     take: 20,
     skip: offset,
     where: {
+      AND: [query.query.content, query.query.play, query.query.timeZone],
       isOfficial: false,
-      ...query,
+      ...query.year,
     },
-    orderBy: [{ beginTime: orderBy }],
+    orderBy: { beginTime: query.orderBy },
     include: {
       tags: {
         include: {

--- a/app/_utile/prisma/index.ts
+++ b/app/_utile/prisma/index.ts
@@ -70,8 +70,15 @@ export const getChannelWhereOffset = async (
     orderBy: { beginTime: query.orderBy },
     include: {
       tags: {
-        include: {
-          tags: true,
+        select: {
+          tags: {
+            select: {
+              id: true,
+              name: true,
+              code: true,
+              type: true,
+            },
+          },
         },
       },
     },


### PR DESCRIPTION
## Issue / Ticket

### 作業カテゴリー

#142 

### 作業チケット

[#151 Where文にincludeを追加し、Channelテーブルの情報を取得できるようにする](https://trello.com/c/x3xoctdt/96-151-where%E6%96%87%E3%81%ABinclude%E3%82%92%E8%BF%BD%E5%8A%A0%E3%81%97%E3%80%81channel%E3%83%86%E3%83%BC%E3%83%96%E3%83%AB%E3%81%AE%E6%83%85%E5%A0%B1%E3%82%92%E5%8F%96%E5%BE%97%E3%81%A7%E3%81%8D%E3%82%8B%E3%82%88%E3%81%86%E3%81%AB%E3%81%99%E3%82%8B)

## 課題/何が起こったか

ユーザーが配信者を見つけるために、ユーザーが自分にあった、もしくは見たいニーズの配信を行っているVtuberを見つけたい

## 仮説/どうしてそうなったのか

プレイスタイル・PTプレイ・配信時間帯などのカテゴリーごとタグとしてVtuberの情報として紐付ける工程は完了した
次はPrismaのORMを使い、カテゴリー毎に選ばれたのはAND条件。
カテゴリー内のタグ情報がはそれぞれOR条件とする。
これは、カテゴリーそれぞれに対しては、ユーザーはカテゴリー内で選択したのを含むVtuberを見つけたい。
カテゴリー毎では、そのカテゴリーは必ず含まれているVtuberを見つけたいという思考になるため。

## どういう作業を行ったか

Channelテーブルに対して、交差テーブルのTaggingテーブルをLeftJoinをし、検索をするようにする。
前回はWhere文を作っていたが、今回はメインのPrismaの関数を変更をし対応

## Next Point

 - 関係のあるコミットをまとめたら、大きなPRとなった気がする部分

## 変更画面のサンプル

- none 

## 参考資料
[ブログで指定したタグ全てに紐付いた記事を検索する - この記事のSQLを参考にし、ChatGPTで生成](https://qiita.com/ak-ymst/items/506ae4f176596488d1ac)

```
const test = await prisma.channel.findMany({
  where: {
    AND: [
      {
        tags: {
          some: {
            OR: [{ tag_id: 3 }, { tag_id: 4 }],
          },
        },
      },
      {
        tags: {
          some: {
            OR: [{ tag_id: 13 }],
          },
        },
      },
    ],
  },
});
```



