### PR TITLE
反映 - 件数をカウントするクエリも、検索クエリと同じ構文にし、同結果を返すようにする

### DIFF
--- a/app/_utile/prisma/index.ts
+++ b/app/_utile/prisma/index.ts
@@ -92,14 +92,16 @@ export const getChannelWhereOffset = async (
  * @param query 検索条件 - PrismaのWhereの型を利用しオブジェクトを作成し渡す
  * @returns
  */
-export const getChannelWhereCount = async (query: Prisma.ChannelWhereInput) => {
-  const res = await prisma.channel.count({
+export const getChannelWhereCount = async (offset = 0, query: PrismaQuery) => {
+  return await prisma.channel.count({
+    take: 20,
+    skip: offset,
     where: {
+      AND: [query.query.content, query.query.play, query.query.timeZone],
       isOfficial: false,
-      ...query,
+      ...query.year,
     },
   });
-  return res;
 };
 
 export default prisma;

--- a/app/_utile/prisma/index.ts
+++ b/app/_utile/prisma/index.ts
@@ -1,4 +1,4 @@
-import { HikasenVtuber, Tags, Tag } from '@/(types)';
+import { HikasenVtuber, Tags } from '@/(types)';
 import { PrismaClient, Prisma } from '@prisma/client';
 
 import { convertTaggingToTags } from '@/_utile/convert';

--- a/app/channels/_lib/api/getChannelWhere.ts
+++ b/app/channels/_lib/api/getChannelWhere.ts
@@ -17,7 +17,7 @@ export const getChannelWhere = async (
     offsetNumber === 1 ? 0 : BASE_QUERY_COUNT * (offsetNumber - 1) + 1;
 
   const res = await getChannelWhereOffset(skip, query);
-  const count = await getChannelWhereCount(query);
+  const count = await getChannelWhereCount(skip, query);
 
   return [res, count] as const;
 };

--- a/app/channels/_lib/api/getChannelWhere.ts
+++ b/app/channels/_lib/api/getChannelWhere.ts
@@ -1,6 +1,6 @@
 import { getChannelWhereCount, getChannelWhereOffset } from '@/_utile/prisma';
 import { ChannelSearchParams } from '@/channels/(types)';
-import { Prisma } from '@prisma/client';
+import { createWhereQuery } from '../prisma/createChannelQuery';
 
 export const getChannelWhere = async (
   params: ChannelSearchParams,
@@ -16,7 +16,7 @@ export const getChannelWhere = async (
   const skip =
     offsetNumber === 1 ? 0 : BASE_QUERY_COUNT * (offsetNumber - 1) + 1;
 
-  const res = await getChannelWhereOffset(skip, query, 'desc');
+  const res = await getChannelWhereOffset(skip, query);
   const count = await getChannelWhereCount(query);
 
   return [res, count] as const;


### PR DESCRIPTION
## Issue / Ticket

### 作業カテゴリー

#142 

### 作業チケット

[#151 Where文にincludeを追加し、Channelテーブルの情報を取得できるようにする](https://trello.com/c/x3xoctdt/96-151-where%E6%96%87%E3%81%ABinclude%E3%82%92%E8%BF%BD%E5%8A%A0%E3%81%97%E3%80%81channel%E3%83%86%E3%83%BC%E3%83%96%E3%83%AB%E3%81%AE%E6%83%85%E5%A0%B1%E3%82%92%E5%8F%96%E5%BE%97%E3%81%A7%E3%81%8D%E3%82%8B%E3%82%88%E3%81%86%E3%81%AB%E3%81%99%E3%82%8B)

## 課題/何が起こったか

検索で配信者を見つける事が出来るようになったが、件数取得処理はロジックが対応していなくて、件数にズレがでている

## 仮説/どうしてそうなったのか

Prismaで件数カウントの場合は別途テーブルに対して件数を取得するロジックを作る必要があるため。

## どういう作業を行ったか

条件文を件数を取るクエリ文に移植した

## Next Point

 - Where文は共有化できるのでは？

## 変更画面のサンプル

- none 

## 参考資料
[ブログで指定したタグ全てに紐付いた記事を検索する - この記事のSQLを参考にし、ChatGPTで生成](https://qiita.com/ak-ymst/items/506ae4f176596488d1ac)

```
const test = await prisma.channel.findMany({
  where: {
    AND: [
      {
        tags: {
          some: {
            OR: [{ tag_id: 3 }, { tag_id: 4 }],
          },
        },
      },
      {
        tags: {
          some: {
            OR: [{ tag_id: 13 }],
          },
        },
      },
    ],
  },
});
```



