### PR TITLE
FIX - 初回ループ時の値が上書きされ、選択内容が消去されていたので、初回ループの処理を消去

### DIFF
--- a/app/api/form/route.ts
+++ b/app/api/form/route.ts
@@ -11,14 +11,12 @@ export async function GET(request: NextRequest) {
   let content = '';
   let play = '';
   let timezone = '';
-  [...queries].forEach((query, index) => {
+  [...queries].forEach((query) => {
     if (query[1] === 'none' || query[1] === '0000') return;
-
-    if (index === 0) return (param = `?${query[0]}=${query[1]}`);
 
     switch (query[0]) {
       case 'sort':
-        return (param = `?sort=${query[1]}`);
+        return (param = `/?sort=${query[1]}`);
       case 'year':
         return (year = `${year}&year=${query[1]}`);
       case 'content':


### PR DESCRIPTION
## Issue

#170 

## 現象
開発環境及び本番環境では、検索画面のチェックボックスを選んだ場合、`プレイスタイル`及び`PTプレイ`に対して、
最初に選んだ物が結果画面では消えている

# 原因
## 対象ファイル
`/api/form`
route.ts

## 事象
ループでformで選択された内容をクエリ文に文字列を作成している。
初回のループでは、接頭詞に`?`をつける必要があるため、対応をしていた。
しかし、変数`param`に生成後の文字列を入れていたが、その後`sort`の文字列を生成をする場合は、
初回の生成内容が上書きされてしまい、消えてしまう。

```ts
 if (index === 0) return (param = `?${query[0]}=${query[1]}`);
```

## なぜ気づかなかったのか
開発環境では、初回が`sort`であったため、上書きされることがなく問題がでなかった。
Vercelの本番環境では、formの順番が変動しているため、事象が発現した。

初回のループが`sort`であれば問題ないが、`sort`のインデックスが0以降であると、問題が発言する。

## どうすればよいか
`form`の順番は変える事ができないため、初回ループ時の処理だけを削除すればよい。

closes #170