### PR TITLE
反映 - クエリパラメータを泥臭くループで処理をしている関数に対して、ユニットテストを実装しロジックの見えるかと品質確認を行う

### DIFF
--- a/app/channels/(types)/index.ts
+++ b/app/channels/(types)/index.ts
@@ -5,7 +5,7 @@ export interface ChannelSearchParams {
   year: string;
   content: string[];
   play: string[];
-  timezone: [];
+  timezone: string[];
 }
 
 export interface PrismaQuery {

--- a/app/channels/__tests__/lib/prisma/createChannelQuery.test.ts
+++ b/app/channels/__tests__/lib/prisma/createChannelQuery.test.ts
@@ -3,3 +3,12 @@ import {
   createWhereQuery,
   createWhereQueryJoinTagging,
 } from '@/channels/_lib/prisma/createChannelQuery';
+
+describe('createChannelQuery Unit TEST', () => {
+  test('クエリパラメータが何も指定されていない時は、プロパティに空のオブジェクトが入ったQueryオブジェクトになる', () => {});
+  test('ソート順を指定するクエリパラメータがある時、指定通りにソートのプロパティが設定されているか', () => {});
+  test('指定年のクエリパラメータがある時、指定年の開始日が1月1日で終了日が12月31日になっているか', () => {});
+  test('プレイスタイル:contentのクエリパラメータがある時、PrismaでINNER JOINをし、OR文になっているか', () => {});
+  test('プレイスタイル:playのクエリパラメータがある時、PrismaでINNER JOINをし、OR文になっているか', () => {});
+  test('プレイスタイル:timezoneのクエリパラメータがある時、PrismaでINNER JOINをし、OR文になっているか', () => {});
+});

--- a/app/channels/__tests__/lib/prisma/createChannelQuery.test.ts
+++ b/app/channels/__tests__/lib/prisma/createChannelQuery.test.ts
@@ -1,4 +1,5 @@
 import { describe, test, expect } from 'vitest';
+import { Prisma } from '@prisma/client';
 import {
   createWhereQuery,
   createWhereQueryJoinTagging,
@@ -125,6 +126,42 @@ describe('createChannelQuery Unit TEST', () => {
     const timezoneQuery = createWhereQuery(content);
 
     expect(timezoneQuery.query.timeZone).toEqual({
+      tags: { some: { OR: [{ tag_id: 19 }, { tag_id: 22 }, { tag_id: 23 }] } },
+    });
+  });
+  test('全てのクエリパラメータが設定されていた時、全てのPrismaWhere文を作成できているか', () => {
+    //timezone:["morning","night","midnight"]
+    const item = createQueryFactory({
+      orderBy: 'desc',
+      year: '2023',
+      content: ['raid', 'story', 'housing'],
+      play: ['party', 'solo', 'farm'],
+      timezone: ['morning', 'night', 'midnight'],
+    });
+
+    const query = createWhereQuery(item);
+
+    const descSort: Prisma.SortOrder = 'desc';
+    const beginDayTime = new Date('2018');
+    const endDayTime = new Date('2018');
+    endDayTime.setMonth(12);
+    endDayTime.setSeconds(-1);
+    const beginTimeQuery: Prisma.ChannelWhereInput = {
+      beginTime: {
+        gte: beginDayTime.toISOString(),
+        lt: endDayTime.toISOString(),
+      },
+    };
+
+    expect(query.orderBy).toEqual(descSort);
+    expect(query.year).toEqual(beginTimeQuery);
+    expect(query.query.content).toEqual({
+      tags: { some: { OR: [{ tag_id: 3 }, { tag_id: 1 }, { tag_id: 4 }] } },
+    });
+    expect(query.query.play).toEqual({
+      tags: { some: { OR: [{ tag_id: 13 }, { tag_id: 14 }, { tag_id: 17 }] } },
+    });
+    expect(query.query.timeZone).toEqual({
       tags: { some: { OR: [{ tag_id: 19 }, { tag_id: 22 }, { tag_id: 23 }] } },
     });
   });

--- a/app/channels/__tests__/lib/prisma/createChannelQuery.test.ts
+++ b/app/channels/__tests__/lib/prisma/createChannelQuery.test.ts
@@ -3,6 +3,39 @@ import {
   createWhereQuery,
   createWhereQueryJoinTagging,
 } from '@/channels/_lib/prisma/createChannelQuery';
+import { ChannelSearchParams, PrismaQuery } from '@/channels/(types)';
+
+interface TestParams {
+  orderBy?: Prisma.SortOrder;
+  year?: string;
+  content?: string[];
+  play?: string[];
+  timezone?: string[];
+}
+
+type createQueryFactory = ({
+  orderBy,
+  year,
+  content,
+  play,
+  timezone,
+}: TestParams) => ChannelSearchParams;
+
+const createQueryFactory: createQueryFactory = ({
+  orderBy = 'desc',
+  year = '',
+  content = [],
+  play = [],
+  timezone = [],
+}) => {
+  return {
+    orderBy: orderBy,
+    year: year,
+    content: content,
+    play: play,
+    timezone: timezone,
+  };
+};
 
 describe('createChannelQuery Unit TEST', () => {
   test('クエリパラメータが何も指定されていない時は、プロパティに空のオブジェクトが入ったQueryオブジェクトになる', () => {});

--- a/app/channels/__tests__/lib/prisma/createChannelQuery.test.ts
+++ b/app/channels/__tests__/lib/prisma/createChannelQuery.test.ts
@@ -72,7 +72,26 @@ describe('createChannelQuery Unit TEST', () => {
 
     expect(ascQuery.orderBy).toEqual(ascSort);
   });
-  test('指定年のクエリパラメータがある時、指定年の開始日が1月1日で終了日が12月31日になっているか', () => {});
+  test('指定年のクエリパラメータがある時、指定年の開始日が1月1日で終了日が12月31日になっているか', () => {
+    //year=2018
+    const year = createQueryFactory({ year: '2018' });
+
+    const yearQuery = createWhereQuery(year);
+
+    const beginDayTime = new Date('2018');
+    const endDayTime = new Date('2018');
+    endDayTime.setMonth(12);
+    endDayTime.setSeconds(-1);
+
+    const beginTimeQuery: Prisma.ChannelWhereInput = {
+      beginTime: {
+        gte: beginDayTime.toISOString(),
+        lt: endDayTime.toISOString(),
+      },
+    };
+
+    expect(yearQuery.year).toEqual(beginTimeQuery);
+  });
   test('プレイスタイル:contentのクエリパラメータがある時、PrismaでINNER JOINをし、OR文になっているか', () => {});
   test('プレイスタイル:playのクエリパラメータがある時、PrismaでINNER JOINをし、OR文になっているか', () => {});
   test('プレイスタイル:timezoneのクエリパラメータがある時、PrismaでINNER JOINをし、OR文になっているか', () => {});

--- a/app/channels/__tests__/lib/prisma/createChannelQuery.test.ts
+++ b/app/channels/__tests__/lib/prisma/createChannelQuery.test.ts
@@ -38,7 +38,21 @@ const createQueryFactory: createQueryFactory = ({
 };
 
 describe('createChannelQuery Unit TEST', () => {
-  test('クエリパラメータが何も指定されていない時は、プロパティに空のオブジェクトが入ったQueryオブジェクトになる', () => {});
+  test('クエリパラメータが何も指定されていない時は、プロパティに空のオブジェクトが入ったQueryオブジェクトになる', () => {
+    const query = createWhereQuery();
+
+    const date: PrismaQuery = {
+      query: {
+        content: {},
+        play: {},
+        timeZone: {},
+      },
+      year: {},
+      orderBy: 'desc',
+    };
+
+    expect(query).toEqual(date);
+  });
   test('ソート順を指定するクエリパラメータがある時、指定通りにソートのプロパティが設定されているか', () => {});
   test('指定年のクエリパラメータがある時、指定年の開始日が1月1日で終了日が12月31日になっているか', () => {});
   test('プレイスタイル:contentのクエリパラメータがある時、PrismaでINNER JOINをし、OR文になっているか', () => {});

--- a/app/channels/__tests__/lib/prisma/createChannelQuery.test.ts
+++ b/app/channels/__tests__/lib/prisma/createChannelQuery.test.ts
@@ -92,7 +92,40 @@ describe('createChannelQuery Unit TEST', () => {
 
     expect(yearQuery.year).toEqual(beginTimeQuery);
   });
-  test('プレイスタイル:contentのクエリパラメータがある時、PrismaでINNER JOINをし、OR文になっているか', () => {});
-  test('プレイスタイル:playのクエリパラメータがある時、PrismaでINNER JOINをし、OR文になっているか', () => {});
-  test('プレイスタイル:timezoneのクエリパラメータがある時、PrismaでINNER JOINをし、OR文になっているか', () => {});
+  test('プレイスタイル:contentのクエリパラメータがある時、PrismaでINNER JOINをし、OR文になっているか', () => {
+    //["content",["raid","story","housing"]]
+    const content = createQueryFactory({
+      content: ['raid', 'story', 'housing'],
+    });
+
+    const contentQuery = createWhereQuery(content);
+
+    expect(contentQuery.query.content).toEqual({
+      tags: { some: { OR: [{ tag_id: 3 }, { tag_id: 1 }, { tag_id: 4 }] } },
+    });
+  });
+  test('プレイスタイル:playのクエリパラメータがある時、PrismaでINNER JOINをし、OR文になっているか', () => {
+    //play:["party","solo","farm"]
+    const content = createQueryFactory({
+      play: ['party', 'solo', 'farm'],
+    });
+
+    const playQuery = createWhereQuery(content);
+
+    expect(playQuery.query.play).toEqual({
+      tags: { some: { OR: [{ tag_id: 13 }, { tag_id: 14 }, { tag_id: 17 }] } },
+    });
+  });
+  test('プレイスタイル:timezoneのクエリパラメータがある時、PrismaでINNER JOINをし、OR文になっているか', () => {
+    //timezone:["morning","night","midnight"]
+    const content = createQueryFactory({
+      timezone: ['morning', 'night', 'midnight'],
+    });
+
+    const timezoneQuery = createWhereQuery(content);
+
+    expect(timezoneQuery.query.timeZone).toEqual({
+      tags: { some: { OR: [{ tag_id: 19 }, { tag_id: 22 }, { tag_id: 23 }] } },
+    });
+  });
 });

--- a/app/channels/__tests__/lib/prisma/createChannelQuery.test.ts
+++ b/app/channels/__tests__/lib/prisma/createChannelQuery.test.ts
@@ -1,0 +1,5 @@
+import { describe, test, expect } from 'vitest';
+import {
+  createWhereQuery,
+  createWhereQueryJoinTagging,
+} from '@/channels/_lib/prisma/createChannelQuery';

--- a/app/channels/__tests__/lib/prisma/createChannelQuery.test.ts
+++ b/app/channels/__tests__/lib/prisma/createChannelQuery.test.ts
@@ -53,7 +53,25 @@ describe('createChannelQuery Unit TEST', () => {
 
     expect(query).toEqual(date);
   });
-  test('ソート順を指定するクエリパラメータがある時、指定通りにソートのプロパティが設定されているか', () => {});
+  test('ソート順を指定するクエリパラメータがある時、指定通りにソートのプロパティが設定されているか', () => {
+    //sort=desc
+    const desc = createQueryFactory({ orderBy: 'desc' });
+
+    const descQuery = createWhereQuery(desc);
+
+    const descSort: Prisma.SortOrder = 'desc';
+
+    expect(descQuery.orderBy).toEqual(descSort);
+
+    //sort=desc
+    const asc = createQueryFactory({ orderBy: 'asc' });
+
+    const ascQuery = createWhereQuery(asc);
+
+    const ascSort: Prisma.SortOrder = 'asc';
+
+    expect(ascQuery.orderBy).toEqual(ascSort);
+  });
   test('指定年のクエリパラメータがある時、指定年の開始日が1月1日で終了日が12月31日になっているか', () => {});
   test('プレイスタイル:contentのクエリパラメータがある時、PrismaでINNER JOINをし、OR文になっているか', () => {});
   test('プレイスタイル:playのクエリパラメータがある時、PrismaでINNER JOINをし、OR文になっているか', () => {});

--- a/app/channels/_lib/prisma/createChannelQuery.ts
+++ b/app/channels/_lib/prisma/createChannelQuery.ts
@@ -86,6 +86,8 @@ export const createWhereQuery = (params?: ChannelSearchParams): PrismaQuery => {
       case 'year': {
         if (Array.isArray(value[1])) return;
 
+        if (value[1] === '') return;
+
         const time = new Date(value[1]);
 
         //まずは配信時間のWhere文だけを作成する

--- a/app/channels/_lib/prisma/createChannelQuery.ts
+++ b/app/channels/_lib/prisma/createChannelQuery.ts
@@ -69,17 +69,17 @@ export const createWhereQuery = (params?: ChannelSearchParams): PrismaQuery => {
 
   //クエリパラメータをループで処理し、queryオブジェクトにマージしていくことで、1つの検索条件オブジェクトとする
   let year: Prisma.ChannelWhereInput = {};
-  let orderBy: Prisma.SortOrder = 'desc';
+  let orderBy: Prisma.SortOrder;
   let contentQuery: Prisma.ChannelWhereInput = {};
   let playQuery: Prisma.ChannelWhereInput = {};
   let timezoneQuery: Prisma.ChannelWhereInput = {};
 
   keys.forEach((value) => {
     switch (value[0]) {
-      case 'sort':
+      case 'orderBy':
         if (Array.isArray(value[1])) return;
 
-        if (value[1] === 'asc') return (orderBy = 'desc');
+        if (value[1] === 'desc') return (orderBy = 'desc');
 
         orderBy = 'asc';
         break;


### PR DESCRIPTION


## Issue / Ticket
### 作業チケット

#178 

closes #178

## 課題/何が起こったか

コードレビューを行って頂いた時に、レビュアーがコードの意図の把握に時間がかかってしまい、意図を把握し辛いと指摘を頂いた。

## 仮説/どうしてそうなったのか

クエリ作成関数は、クエリパラメータをループで順に処理をしており、更にSwitch文で分岐しているため、
ロジックが長くなっており、どんなデータがどういう風に加工されるか理解しにくい構成となっていた

## どういう作業を行ったか

ループ処理に対してはコメントを書くのではなく、ユニットテストを実装することで、
どういうデータがどういう風に加工されるかを示しながら、想定通りのロジックになっているかを確認する

## Next Point

 - コメントも書いたほうがよいかもしれない

## 変更画面のサンプル

- none 

## 参考資料

- none

