### PR TITLE
反映 - ログイン画面の構成を、PC画面では2カラムにする

### DIFF
--- a/app/_components/Sign/sign.module.scss
+++ b/app/_components/Sign/sign.module.scss
@@ -1,5 +1,5 @@
 .signin {
-  width: 200px;
+  width: 100%;
   height: 40px;
   border-radius: 10px;
 

--- a/app/_components/Sign/sign.module.scss
+++ b/app/_components/Sign/sign.module.scss
@@ -3,6 +3,9 @@
   height: 40px;
   border-radius: 10px;
 
+  cursor: pointer;
+
+
   & .green {
     background-color: rgb(38, 189, 38);
   }

--- a/app/_components/Sign/sign.module.scss
+++ b/app/_components/Sign/sign.module.scss
@@ -5,6 +5,11 @@
 
   cursor: pointer;
 
+  background-color: transparent;
+  border: 1px solid #777777;
+
+  color: #d8d8d8;
+  font-weight: 700;
 
   & .green {
     background-color: rgb(38, 189, 38);

--- a/app/_styles/rootLayout.module.scss
+++ b/app/_styles/rootLayout.module.scss
@@ -24,6 +24,6 @@
   height: 100%;
 
   @include variables.mq(lg) {
-    grid-area: 2 / 2 / 3 / 3;
+    grid-area: 2 / 1 / 3 / 4;
   }
 }

--- a/app/_styles/rootLayout.module.scss
+++ b/app/_styles/rootLayout.module.scss
@@ -19,7 +19,7 @@
 }
 
 .main_container {
-  height: 100%;
+  height: calc(100% - 50px);
 
   @include variables.mq(lg) {
     grid-area: 2 / 1 / 3 / 4;

--- a/app/_styles/rootLayout.module.scss
+++ b/app/_styles/rootLayout.module.scss
@@ -21,6 +21,10 @@
 .main_container {
   height: calc(100% - 50px);
 
+  @include variables.mq(md) {
+    height: 100%;
+  }
+
   @include variables.mq(lg) {
     grid-area: 2 / 1 / 3 / 4;
   }

--- a/app/_styles/rootLayout.module.scss
+++ b/app/_styles/rootLayout.module.scss
@@ -19,8 +19,6 @@
 }
 
 .main_container {
-  margin-left: 10px;
-  margin-right: 10px;
   height: 100%;
 
   @include variables.mq(lg) {

--- a/app/_styles/rootPage.module.scss
+++ b/app/_styles/rootPage.module.scss
@@ -2,15 +2,22 @@
 
 $forcus_color: #687792;
 
+.container {
+  display: grid;
+  grid-template-columns: 0.5fr 3fr 0.5fr;
+}
+
 .content {
   display: flex;
   min-height: 100%;
   flex-direction: column;
   align-items: center;
   // justify-content: space-between;
+
+  grid-area: 2 / 2 / 3 / 3;
 }
 
-.search_container {
+.search_content {
   width: 100%;
   display: flex;
   align-items: center;

--- a/app/auth/_styles/signin.module.scss
+++ b/app/auth/_styles/signin.module.scss
@@ -29,6 +29,7 @@
     flex-direction: column;
     justify-content: center;
 
+    gap: 20px;
   }
 }
 

--- a/app/auth/_styles/signin.module.scss
+++ b/app/auth/_styles/signin.module.scss
@@ -20,6 +20,10 @@
   display: grid;
   place-items: center;
 
+  @include variables.mq(md) {
+    border-right: 1px solid #8b8b8b;
+  }
+
   & .content {
     max-width: 400px;
     height: 100%;

--- a/app/auth/_styles/signin.module.scss
+++ b/app/auth/_styles/signin.module.scss
@@ -1,12 +1,31 @@
+@use '@/_styles/variables/variables.scss';
+
 .container {
-  height: 80%;
   display: grid;
   place-items: center;
+  width: 100%;
+  height: 100%;
+
+  @include variables.mq(lg) {
+    display: flex;
+  }
 }
 
-.content {
+.main {
+  box-sizing: border-box;
+  height: 100%;
+
+  flex-grow: 1;
+  border-right-width: 1px;
   display: grid;
   place-items: center;
+
+}
+
+.side {
+  flex-basis: 25%;
+  height: 100%;
+  flex-grow: 3;
 }
 
 .message {

--- a/app/auth/_styles/signin.module.scss
+++ b/app/auth/_styles/signin.module.scss
@@ -20,6 +20,11 @@
   display: grid;
   place-items: center;
 
+  & .content {
+    max-width: 400px;
+    height: 100%;
+    padding: 30px;
+  }
 }
 
 .side {

--- a/app/auth/_styles/signin.module.scss
+++ b/app/auth/_styles/signin.module.scss
@@ -31,7 +31,8 @@
   display: none;
 
   @include variables.mq(md) {
-    display: inline-block;
+    display: grid;
+    place-items: center;
     flex-basis: 25%;
     height: 100%;
     flex-grow: 3;

--- a/app/auth/_styles/signin.module.scss
+++ b/app/auth/_styles/signin.module.scss
@@ -24,6 +24,11 @@
     max-width: 400px;
     height: 100%;
     padding: 30px;
+
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+
   }
 }
 

--- a/app/auth/_styles/signin.module.scss
+++ b/app/auth/_styles/signin.module.scss
@@ -6,7 +6,7 @@
   width: 100%;
   height: 100%;
 
-  @include variables.mq(lg) {
+  @include variables.mq(md) {
     display: flex;
   }
 }
@@ -23,16 +23,19 @@
 }
 
 .side {
-  flex-basis: 25%;
-  height: 100%;
-  flex-grow: 3;
+  display: none;
+
+  @include variables.mq(md) {
+    display: inline-block;
+    flex-basis: 25%;
+    height: 100%;
+    flex-grow: 3;
+  }
 }
 
 .message {
   margin-bottom: 15px;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
+  text-align: left;
 }
 
 .signin_text {

--- a/app/auth/signin/page.tsx
+++ b/app/auth/signin/page.tsx
@@ -4,7 +4,7 @@ import { SignIn } from '@/_components/Sign';
 export default function AuthSignIn() {
   return (
     <div className={styles.container}>
-      <div className={styles.content}>
+      <main className={styles.main}>
         <main>
           <div className={styles.message}>
             <span>お持ちのアカウントを使いログインをします</span>
@@ -14,8 +14,8 @@ export default function AuthSignIn() {
             <span className={styles.signin_text}>Googleでログイン</span>
           </SignIn>
         </main>
-        <aside>暁月</aside>
-      </div>
+      </main>
+      <aside className={styles.side}>暁月</aside>
     </div>
   );
 }

--- a/app/auth/signin/page.tsx
+++ b/app/auth/signin/page.tsx
@@ -5,15 +5,15 @@ export default function AuthSignIn() {
   return (
     <div className={styles.container}>
       <main className={styles.main}>
-        <main>
+        <div className={styles.content}>
           <div className={styles.message}>
-            <span>お持ちのアカウントを使いログインをします</span>
-            <span>※現在ログイン機能は停止中です</span>
+            <h1>ログイン</h1>
+            <span>お持ちのアカウントでログインできます</span>
           </div>
           <SignIn provider="github">
             <span className={styles.signin_text}>Googleでログイン</span>
           </SignIn>
-        </main>
+        </div>
       </main>
       <aside className={styles.side}>暁月</aside>
     </div>

--- a/app/auth/signin/page.tsx
+++ b/app/auth/signin/page.tsx
@@ -15,7 +15,9 @@ export default function AuthSignIn() {
           </SignIn>
         </div>
       </main>
-      <aside className={styles.side}>暁月</aside>
+      <aside className={styles.side}>
+        <div>暁月</div>
+      </aside>
     </div>
   );
 }

--- a/app/auth/signin/page.tsx
+++ b/app/auth/signin/page.tsx
@@ -5,13 +5,16 @@ export default function AuthSignIn() {
   return (
     <div className={styles.container}>
       <div className={styles.content}>
-        <div className={styles.message}>
-          <span>お持ちのアカウントを使いログインをします</span>
-          <span>※現在ログイン機能は停止中です</span>
-        </div>
-        <SignIn provider="github">
-          <span className={styles.signin_text}>Googleでログイン</span>
-        </SignIn>
+        <main>
+          <div className={styles.message}>
+            <span>お持ちのアカウントを使いログインをします</span>
+            <span>※現在ログイン機能は停止中です</span>
+          </div>
+          <SignIn provider="github">
+            <span className={styles.signin_text}>Googleでログイン</span>
+          </SignIn>
+        </main>
+        <aside>暁月</aside>
       </div>
     </div>
   );

--- a/app/channels/[pages]/page.tsx
+++ b/app/channels/[pages]/page.tsx
@@ -12,7 +12,7 @@ export default async function Article({
   const [channels, count] = await getChannel(params.pages);
   return (
     <div className={styles.content}>
-      <div className={styles.search_container}>
+      <div className={styles.search_content}>
         <Link className={styles.link} href={'/channels/search'}>
           配信者を探す→
         </Link>

--- a/app/channels/layout.tsx
+++ b/app/channels/layout.tsx
@@ -1,0 +1,13 @@
+import styles from '@/_styles/rootPage.module.scss';
+
+export default function ChannelsLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return (
+    <div className={styles.container}>
+      <div className={styles.content}>{children}</div>
+    </div>
+  );
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -30,9 +30,9 @@ export default function RootLayout({
         <header className={styles.header}>
           <BasicHeader></BasicHeader>
         </header>
-        <main className={styles.main_container}>
+        <div className={styles.main_container}>
           <RecoilProvider>{children}</RecoilProvider>
-        </main>
+        </div>
       </body>
     </html>
   );

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -17,13 +17,15 @@ const getChannel = async (): Promise<
 export default async function Home() {
   const [channels, totalCount] = await getChannel();
   return (
-    <section className={styles.content}>
-      <div className={styles.search_container}>
-        <Link className={styles.link} href={'/channels/search'}>
-          配信者を探す→
-        </Link>
+    <div className={styles.container}>
+      <div className={styles.content}>
+        <div className={styles.search_content}>
+          <Link className={styles.link} href={'/channels/search'}>
+            配信者を探す→
+          </Link>
+        </div>
+        <ChannelIndex totalCount={totalCount} channels={channels} page="1" />
       </div>
-      <ChannelIndex totalCount={totalCount} channels={channels} page="1" />
-    </section>
+    </div>
   );
 }


### PR DESCRIPTION
## Issue / Ticket
### 作業チケット

#173 

closes #173 

## 課題/何が起こったか

Vtuberの登録を行う必要があり、ユーザーアカウント機能の実装が必要

## 仮説/どうしてそうなったのか

ユーザーアカウント機能の実装が必要であるが、ログイン認証周りの画面が機能として実装されていない
以前に作成したログイン画面があるが、スタイルを完全には整えていないので使用できない

## どういう作業を行ったか

PC画面では右に現在のFF14の最新コンテンツのロゴや、当サービスのロゴなどを表示したいので、2カラムにする。
スマホ画面では、ログイン機能のmainコンテンツ部分だけを表示するように、レスポンシブ対応をする

## Next Point

- 背景色を後々変えるため、ログインページでも色は変えるべき

## 変更画面のサンプル
### 変更前

![1415d69bf198be1b6d80482e28145b41](https://github.com/OKAUEND/ffxiv_vtuber_archives/assets/38197580/2c3995d0-fc73-48b0-9928-1b7e60f30fca)
![92b1ad71ead65a57de8aeca25beb20d2](https://github.com/OKAUEND/ffxiv_vtuber_archives/assets/38197580/1a875750-0e85-407c-84dc-ef909103e264)

### 変更後
![6cb435585dee4da4d1101652cc486bc3](https://github.com/OKAUEND/ffxiv_vtuber_archives/assets/38197580/1b1396fd-791c-4d69-ac0e-0327c480c62c)
![7d7a9b4d08ebe1c7affcdb2004cf3099](https://github.com/OKAUEND/ffxiv_vtuber_archives/assets/38197580/7c9b8128-9725-4ec9-8c48-dc968729956a)

## 参考資料

- none



