### PR TITLE
反映 - ヘッダー項目にログイン画面へのリンクを設置する

### DIFF
--- a/app/_components/Header/header.module.scss
+++ b/app/_components/Header/header.module.scss
@@ -20,7 +20,23 @@
   margin-right: 10px;
 
   .href {
+    font-size: 14px;
+    background-color: transparent;
     color: variables.$text-color;
     text-decoration: none;
+
+    &.border {
+      border: 1px solid variables.$text-color;
+      border-radius: 5px;
+      padding: 5px;
+
+      &:hover {
+        background-color: #535353;
+      }
+    }
+
+    &:hover {
+      cursor: pointer;
+    }
   }
 }

--- a/app/_components/Header/header.tsx
+++ b/app/_components/Header/header.tsx
@@ -11,7 +11,11 @@ export const BasicHeader = () => {
         {items.map((item, index) => (
           <li className={styles.header_links} key={index}>
             <Link href={item.path}>
-              <button>{item.text}</button>
+              <button
+                className={`${styles.href} ${item.border ? styles.border : ''}`}
+              >
+                {item.text}
+              </button>
             </Link>
           </li>
         ))}

--- a/app/_components/Header/header.tsx
+++ b/app/_components/Header/header.tsx
@@ -10,8 +10,8 @@ export const BasicHeader = () => {
       <ul className={styles.header_list}>
         {items.map((item, index) => (
           <li className={styles.header_links} key={index}>
-            <Link className={styles.href} href={item.path}>
-              {item.text}
+            <Link href={item.path}>
+              <button>{item.text}</button>
             </Link>
           </li>
         ))}

--- a/app/_components/Header/hook/index.ts
+++ b/app/_components/Header/hook/index.ts
@@ -1,6 +1,7 @@
 export const useHeader = () => {
   return [
-    { text: 'トップ', path: '/' },
-    { text: 'このサイトについて', path: '/about' },
+    { text: 'トップ', path: '/', border: false },
+    { text: 'サイトについて', path: '/about', border: false },
+    { text: 'Sign in', path: '/auth/singin', border: true },
   ];
 };


### PR DESCRIPTION
## Issue / Ticket
### 作業チケット

#188 

closes #188 

## 課題/何が起こったか

ログイン画面は完成したが、ログイン画面へ移動するためのリンクなどが用意されていない

## 仮説/どうしてそうなったのか

ログイン画面は #173 にて実装を行えたが、その画面へ遷移する方法がパスをダイレクト入力する必要がある

## どういう作業を行ったか

そのため、ヘッダーなどに、ログイン画面へのリンクを設置する
なお、ログイン画面へのリンクは他と違う事をデザインで表現するため、
枠線で囲い、マウスなどでカーソルが乗った時は背景色も変更をする

## Next Point

- ログインが出来た場合などでは、表示をマイページかSNSのアイコンなどに変更をする必要がある。

## 変更画面のサンプル
### 変更前

![1415d69bf198be1b6d80482e28145b4sadasfasf1](https://github.com/OKAUEND/ffxiv_vtuber_archives/assets/38197580/e90f147d-a246-449e-be76-ad6db2c7b627)

### 変更後
![8317d6c0bc3962c12b0c5b0082ed75e4](https://github.com/OKAUEND/ffxiv_vtuber_archives/assets/38197580/eb90ae8f-cbfd-4207-a8a4-8fc3aa8d10f7)
![f985d30e7ab5db36208540052648248a](https://github.com/OKAUEND/ffxiv_vtuber_archives/assets/38197580/6c3a0ac5-ab9a-4629-be27-5f62b8bc0c5b)


## 参考資料

- none



